### PR TITLE
Feature/noti 12 수업 lesson 도메인 구현

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -29,6 +29,10 @@ dependencies {
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
 	testImplementation 'org.springframework.security:spring-security-test'
+	testCompileOnly 'org.projectlombok:lombok'
+	testAnnotationProcessor 'org.projectlombok:lombok'
+	testImplementation 'org.testcontainers:junit-jupiter:1.17.5'
+	testImplementation 'org.testcontainers:mysql:1.17.5'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/noti/noti/common/adapter/out/persistance/jpa/model/BaseTimeEntity.java
+++ b/src/main/java/com/noti/noti/common/adapter/out/persistance/jpa/model/BaseTimeEntity.java
@@ -1,0 +1,24 @@
+package com.noti.noti.common.adapter.out.persistance.jpa.model;
+
+import java.time.LocalDateTime;
+import javax.persistence.Column;
+import javax.persistence.EntityListeners;
+import javax.persistence.MappedSuperclass;
+import lombok.Getter;
+import org.springframework.data.annotation.CreatedDate;
+import org.springframework.data.annotation.LastModifiedDate;
+import org.springframework.data.jpa.domain.support.AuditingEntityListener;
+
+@Getter
+@MappedSuperclass
+@EntityListeners(AuditingEntityListener.class)
+public class BaseTimeEntity {
+
+  @CreatedDate
+  @Column(name = "created_at")
+  private LocalDateTime createdAt;
+
+  @LastModifiedDate
+  @Column(name = "modified_at")
+  private LocalDateTime modifiedAt;
+}

--- a/src/main/java/com/noti/noti/config/JpaConfig.java
+++ b/src/main/java/com/noti/noti/config/JpaConfig.java
@@ -1,0 +1,10 @@
+package com.noti.noti.config;
+
+import org.springframework.context.annotation.Configuration;
+import org.springframework.data.jpa.repository.config.EnableJpaAuditing;
+
+@Configuration
+@EnableJpaAuditing
+public class JpaConfig {
+
+}

--- a/src/main/java/com/noti/noti/lesson/adapter/out/persistence/LessonMapper.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/out/persistence/LessonMapper.java
@@ -1,0 +1,29 @@
+package com.noti.noti.lesson.adapter.out.persistence;
+
+import com.noti.noti.lesson.adapter.out.persistence.jpa.model.LessonJpaEntity;
+import com.noti.noti.lesson.domain.model.Lesson;
+import org.springframework.stereotype.Component;
+
+@Component
+public class LessonMapper {
+
+  Lesson mapToDomainEntity(LessonJpaEntity lessonJpaEntity) {
+    return Lesson.builder()
+        .id(lessonJpaEntity.getId())
+        .lessonName(lessonJpaEntity.getLessonName())
+        .startTime(lessonJpaEntity.getStartTime())
+        .endTime(lessonJpaEntity.getEndTime())
+        .createdAt(lessonJpaEntity.getCreatedAt())
+        .modifiedAt(lessonJpaEntity.getModifiedAt())
+        .build();
+  }
+
+  LessonJpaEntity mapToJpaEntity(Lesson lesson) {
+    return LessonJpaEntity.builder()
+        .id(lesson.getId())
+        .lessonName(lesson.getLessonName())
+        .endTime(lesson.getEndTime())
+        .startTime(lesson.getStartTime())
+        .build();
+  }
+}

--- a/src/main/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapter.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapter.java
@@ -1,0 +1,23 @@
+package com.noti.noti.lesson.adapter.out.persistence;
+
+import com.noti.noti.lesson.adapter.out.persistence.jpa.LessonJpaRepository;
+import com.noti.noti.lesson.adapter.out.persistence.jpa.model.LessonJpaEntity;
+import com.noti.noti.lesson.application.port.out.SaveLessonPort;
+import com.noti.noti.lesson.domain.model.Lesson;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+import org.springframework.stereotype.Repository;
+
+@Repository
+@RequiredArgsConstructor
+public class LessonPersistenceAdapter implements SaveLessonPort {
+
+  private final LessonJpaRepository lessonJpaRepository;
+  private final LessonMapper lessonMapper;
+
+  @Override
+  public Lesson saveLesson(Lesson lesson) {
+    LessonJpaEntity lessonJpaEntity = lessonJpaRepository.save(lessonMapper.mapToJpaEntity(lesson));
+    return lessonMapper.mapToDomainEntity(lessonJpaEntity);
+  }
+}

--- a/src/main/java/com/noti/noti/lesson/adapter/out/persistence/jpa/LessonJpaRepository.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/out/persistence/jpa/LessonJpaRepository.java
@@ -1,0 +1,8 @@
+package com.noti.noti.lesson.adapter.out.persistence.jpa;
+
+import com.noti.noti.lesson.adapter.out.persistence.jpa.model.LessonJpaEntity;
+import org.springframework.data.jpa.repository.JpaRepository;
+
+public interface LessonJpaRepository extends JpaRepository<LessonJpaEntity, Long> {
+
+}

--- a/src/main/java/com/noti/noti/lesson/adapter/out/persistence/jpa/model/LessonJpaEntity.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/out/persistence/jpa/model/LessonJpaEntity.java
@@ -1,0 +1,47 @@
+package com.noti.noti.lesson.adapter.out.persistence.jpa.model;
+
+import com.noti.noti.common.adapter.out.persistance.jpa.model.BaseTimeEntity;
+import java.time.LocalTime;
+import javax.persistence.Column;
+import javax.persistence.Entity;
+import javax.persistence.GeneratedValue;
+import javax.persistence.GenerationType;
+import javax.persistence.Id;
+import javax.persistence.Table;
+import lombok.AccessLevel;
+import lombok.Builder;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Entity
+@Table(name = "lesson")
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+@Getter
+public class LessonJpaEntity extends BaseTimeEntity {
+
+  @Id
+  @GeneratedValue(strategy = GenerationType.IDENTITY)
+  @Column(name = "lesson_id")
+  private Long id;
+
+//  @ManyToOne
+//  @JoinColumn(name = "teacher_id")
+//  private Teacher teacher;
+
+  @Column
+  private String lessonName;
+
+  @Column
+  private LocalTime startTime;
+
+  @Column
+  private LocalTime endTime;
+
+  @Builder
+  public LessonJpaEntity(Long id, String lessonName, LocalTime startTime, LocalTime endTime) {
+    this.id = id;
+    this.lessonName = lessonName;
+    this.startTime = startTime;
+    this.endTime = endTime;
+  }
+}

--- a/src/main/java/com/noti/noti/lesson/application/port/out/SaveLessonPort.java
+++ b/src/main/java/com/noti/noti/lesson/application/port/out/SaveLessonPort.java
@@ -1,0 +1,8 @@
+package com.noti.noti.lesson.application.port.out;
+
+import com.noti.noti.lesson.domain.model.Lesson;
+
+public interface SaveLessonPort {
+
+  Lesson saveLesson(Lesson lesson);
+}

--- a/src/main/java/com/noti/noti/lesson/domain/model/Lesson.java
+++ b/src/main/java/com/noti/noti/lesson/domain/model/Lesson.java
@@ -1,0 +1,29 @@
+package com.noti.noti.lesson.domain.model;
+
+import java.time.LocalDateTime;
+import java.time.LocalTime;
+import lombok.Builder;
+import lombok.Getter;
+
+@Getter
+public class Lesson {
+  private Long id;
+
+  //private Teacher teacher;
+  private String lessonName;
+  private LocalTime startTime;
+  private LocalTime endTime;
+  private LocalDateTime createdAt;
+  private LocalDateTime modifiedAt;
+
+  @Builder
+  public Lesson(Long id, String lessonName, LocalTime startTime, LocalTime endTime,
+      LocalDateTime createdAt, LocalDateTime modifiedAt) {
+    this.id = id;
+    this.lessonName = lessonName;
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.createdAt = createdAt;
+    this.modifiedAt = modifiedAt;
+  }
+}

--- a/src/test/java/com/noti/noti/NotiApplicationTests.java
+++ b/src/test/java/com/noti/noti/NotiApplicationTests.java
@@ -2,8 +2,10 @@ package com.noti.noti;
 
 import org.junit.jupiter.api.Test;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.ActiveProfiles;
 
 @SpringBootTest
+@ActiveProfiles("test")
 class NotiApplicationTests {
 
 	@Test

--- a/src/test/java/com/noti/noti/lesson/adapter/out/persistence/LessonMapperTest.java
+++ b/src/test/java/com/noti/noti/lesson/adapter/out/persistence/LessonMapperTest.java
@@ -1,0 +1,60 @@
+package com.noti.noti.lesson.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.noti.noti.lesson.adapter.out.persistence.jpa.model.LessonJpaEntity;
+import com.noti.noti.lesson.domain.model.Lesson;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+
+@DisplayName("LessonMapper 클래스")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class LessonMapperTest {
+
+  private LessonMapper lessonMapper = new LessonMapper();
+
+  @Nested
+  class mapToDomainEntity_메소드는 {
+
+    final LessonJpaEntity givenLessonJpaEntity =
+        LessonJpaEntity.builder()
+            .id(1L)
+            .lessonName("lesson")
+            .build();
+
+    @Nested
+    class Lesson_Jpa_Entity_객체가_주어지면 {
+
+      @Test
+      void Lesson_Domain_객체로_변환하고_변환된_객체를_반환한다() {
+        Lesson mappedEntity = lessonMapper.mapToDomainEntity(givenLessonJpaEntity);
+        assertThat(mappedEntity.getId()).isEqualTo(givenLessonJpaEntity.getId());
+      }
+    }
+  }
+
+  @Nested
+  class mapToJpaEntity_메소드는 {
+
+    @Nested
+    class Lesson_Domain_객체가_주어지면 {
+
+      final Lesson givenLesson =
+          Lesson.builder()
+              .id(1L)
+              .lessonName("Lesson")
+              .build();
+
+      @Test
+      void Lesson_Jpa_Entity_객체로_변환하고_변환된_객체를_반환한다() {
+        LessonJpaEntity mappedLessonJpaEntity = lessonMapper.mapToJpaEntity(givenLesson);
+        assertThat(mappedLessonJpaEntity.getId()).isEqualTo(givenLesson.getId());
+      }
+    }
+  }
+
+
+}

--- a/src/test/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapterTest.java
+++ b/src/test/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapterTest.java
@@ -1,0 +1,45 @@
+package com.noti.noti.lesson.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.noti.noti.lesson.domain.model.Lesson;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.ActiveProfiles;
+
+@DataJpaTest
+@ActiveProfiles("test")
+@Import({LessonPersistenceAdapter.class, LessonMapper.class})
+@DisplayName("LessonPersistenceAdapterTest 클래스")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class LessonPersistenceAdapterTest {
+
+  @Autowired
+  LessonPersistenceAdapter lessonPersistenceAdapter;
+
+  @Nested
+  class save_메소드는 {
+
+    @Nested
+    class Lesson_도메인_객체가_주어지면 {
+
+      final Lesson givenLesson =
+          Lesson.builder()
+              .lessonName("Lesson")
+              .build();
+
+      @Test
+      void 주어진_객체를_저장하고_저장된_mapping된_객체를_반환한다() {
+        Lesson savedLesson = lessonPersistenceAdapter.saveLesson(givenLesson);
+
+        assertThat(savedLesson.getId()).isEqualTo(1L);
+      }
+    }
+  }
+}

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -1,0 +1,24 @@
+spring:
+  test:
+    database:
+      replace: none
+  datasource:
+    driver-class-name: org.testcontainers.jdbc.ContainerDatabaseDriver
+    url: jdbc:tc:mysql:8:///noti
+    username: noti
+    password: noti
+
+  jpa:
+    database-platform: org.hibernate.dialect.MySQL8Dialect
+    hibernate:
+      format_sql: true
+      ddl-auto: create-drop
+    show-sql: true
+
+
+externalUrl: https://github.com/Noti-iOS/noti-backend/wiki
+#logging:
+#  level:
+#    com:
+#      zaxxer:
+#        hikari: debug

--- a/src/test/resources/logback-test.xml
+++ b/src/test/resources/logback-test.xml
@@ -1,0 +1,15 @@
+<configuration>
+  <appender name="STDOUT" class="ch.qos.logback.core.ConsoleAppender">
+    <encoder>
+      <pattern>%d{HH:mm:ss.SSS} [%thread] %-5level %logger - %msg%n</pattern>
+    </encoder>
+  </appender>
+
+  <root level="info">
+    <appender-ref ref="STDOUT"/>
+  </root>
+
+  <logger name="org.testcontainers" level="INFO"/>
+  <logger name="com.github.dockerjava" level="WARN"/>
+  <logger name="com.github.dockerjava.zerodep.shaded.org.apache.hc.client5.http.wire" level="OFF"/>
+</configuration>


### PR DESCRIPTION
## 구현내용

Lesson 도메인 기본 기능 구현했습니다.
- Lesson 도메인 구현
- applicaion savePort 구현
- adapter : mapper, jpaEntity, Repository, PersistenceAdapter  구현
- test 환경에서 사용할 testcontainers 추가

## 변경사항

noti-config 변경사항있어서 submodule 업데이트 해주셔야되요