### PR TITLE
Feature/noti 17 예외처리 로직 구현

### DIFF
--- a/src/main/java/com/noti/noti/error/ErrorCode.java
+++ b/src/main/java/com/noti/noti/error/ErrorCode.java
@@ -3,8 +3,8 @@ package com.noti.noti.error;
 public enum ErrorCode {
 
   // Common
-  INVALID_INPUT_VALUE(400, "C001", " 옳바르지 않는 입력 값 입니다"),
-  METHOD_NOT_ALLOWED(405, "C002", " 옳바르지 않는 입력 값 입니다"),
+  INVALID_INPUT_VALUE(400, "C001", " 올바르지 않은 입력 값입니다"),
+  METHOD_NOT_ALLOWED(405, "C002", " 올바르지 않은 호출입니다"),
   ENTITY_NOT_FOUND(400, "C003", " 정보가 존재하지 않습니다"),
   INTERNAL_SERVER_ERROR(500, "C004", "서버 에러"),
   INVALID_TYPE_VALUE(400, "C005", " 옳바르지 않는 타입의 값을 입력했습니다"),

--- a/src/main/java/com/noti/noti/error/ErrorCode.java
+++ b/src/main/java/com/noti/noti/error/ErrorCode.java
@@ -1,0 +1,44 @@
+package com.noti.noti.error;
+
+public enum ErrorCode {
+
+  // Common
+  INVALID_INPUT_VALUE(400, "C001", " 옳바르지 않는 입력 값 입니다"),
+  METHOD_NOT_ALLOWED(405, "C002", " 옳바르지 않는 입력 값 입니다"),
+  ENTITY_NOT_FOUND(400, "C003", " 정보가 존재하지 않습니다"),
+  INTERNAL_SERVER_ERROR(500, "C004", "서버 에러"),
+  INVALID_TYPE_VALUE(400, "C005", " 옳바르지 않는 타입의 값을 입력했습니다"),
+  HANDLE_ACCESS_DENIED(403, "C006", "접근이 거부되었습니다"),
+
+
+  /*
+  아래에 해당 도메인에 대한 예외 작성
+  */
+
+  // Student
+  STUDENT_NOT_FOUND(404, "S001", " 해당 학생 정보가 존재하지 않습니다");
+
+
+  private int status;
+  private final String code;
+  private final String message;
+
+  ErrorCode(final int status, final String code, final String message) {
+    this.status = status;
+    this.message = message;
+    this.code = code;
+  }
+
+  public int getStatus() {
+    return status;
+  }
+
+  public String getCode() {
+    return code;
+  }
+
+  public String getMessage() {
+    return message;
+  }
+
+}

--- a/src/main/java/com/noti/noti/error/ErrorResponse.java
+++ b/src/main/java/com/noti/noti/error/ErrorResponse.java
@@ -1,0 +1,84 @@
+package com.noti.noti.error;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+import org.springframework.validation.BindingResult;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class ErrorResponse {
+  private String message;
+  private int status;
+  private List<FieldError> errors;
+  private String code;
+
+
+  private ErrorResponse(final ErrorCode code, final List<FieldError> errors) {
+    this.message = code.getMessage();
+    this.status = code.getStatus();
+    this.errors = errors;
+    this.code = code.getCode();
+  }
+
+  private ErrorResponse(final ErrorCode code) {
+    this.message = code.getMessage();
+    this.status = code.getStatus();
+    this.code = code.getCode();
+    this.errors = new ArrayList<>();
+  }
+
+
+  public static ErrorResponse of(final ErrorCode code, final BindingResult bindingResult) {
+    return new ErrorResponse(code, FieldError.of(bindingResult));
+  }
+
+  public static ErrorResponse of(final ErrorCode code) {
+    return new ErrorResponse(code);
+  }
+
+  public static ErrorResponse of(final ErrorCode code, final List<FieldError> errors) {
+    return new ErrorResponse(code, errors);
+  }
+
+  public static ErrorResponse of(MethodArgumentTypeMismatchException e) {
+    final String value = e.getValue() == null ? "" : e.getValue().toString();
+    final List<ErrorResponse.FieldError> errors = ErrorResponse.FieldError.of(e.getName(), value, e.getErrorCode());
+    return new ErrorResponse(ErrorCode.INVALID_INPUT_VALUE, errors);
+  }
+
+
+  @Getter
+  @NoArgsConstructor(access = AccessLevel.PROTECTED)
+  public static class FieldError {
+    private String field;
+    private String value;
+    private String reason;
+
+    private FieldError(final String field, final String value, final String reason) {
+      this.field = field;
+      this.value = value;
+      this.reason = reason;
+    }
+
+    public static List<FieldError> of(final String field, final String value, final String reason) {
+      List<FieldError> fieldErrors = new ArrayList<>();
+      fieldErrors.add(new FieldError(field, value, reason));
+      return fieldErrors;
+    }
+
+    private static List<FieldError> of(final BindingResult bindingResult) {
+      final List<org.springframework.validation.FieldError> fieldErrors = bindingResult.getFieldErrors();
+      return fieldErrors.stream()
+          .map(error -> new FieldError(
+              error.getField(),
+              error.getRejectedValue() == null ? "" : error.getRejectedValue().toString(),
+              error.getDefaultMessage()))
+          .collect(Collectors.toList());
+    }
+  }
+}

--- a/src/main/java/com/noti/noti/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/noti/noti/error/GlobalExceptionHandler.java
@@ -1,0 +1,87 @@
+package com.noti.noti.error;
+
+import com.noti.noti.error.exception.BusinessException;
+import java.nio.file.AccessDeniedException;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.validation.BindException;
+import org.springframework.web.HttpRequestMethodNotSupportedException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
+
+@Slf4j
+@RestControllerAdvice
+public class GlobalExceptionHandler {
+  /**
+   * javax.validation.Valid or @Validated 으로 binding error 발생시 발생한다.
+   * HttpMessageConverter 에서 등록한 HttpMessageConverter binding 못할경우 발생
+   * 주로 @RequestBody, @RequestPart 어노테이션에서 발생
+   */
+  @ExceptionHandler(MethodArgumentNotValidException.class)
+  protected ResponseEntity<ErrorResponse> handleMethodArgumentNotValidException(MethodArgumentNotValidException e) {
+    log.error("handleMethodArgumentNotValidException", e);
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  /**
+   * @ModelAttribut 으로 binding error 발생시 BindException 발생한다.
+   * ref https://docs.spring.io/spring/docs/current/spring-framework-reference/web.html#mvc-ann-modelattrib-method-args
+   */
+  @ExceptionHandler(BindException.class)
+  protected ResponseEntity<ErrorResponse> handleBindException(BindException e) {
+    log.error("handleBindException", e);
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE, e.getBindingResult());
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  /**
+   * enum type 일치하지 않아 binding 못할 경우 발생
+   * 주로 @RequestParam enum으로 binding 못했을 경우 발생
+   */
+  @ExceptionHandler(MethodArgumentTypeMismatchException.class)
+  protected ResponseEntity<ErrorResponse> handleMethodArgumentTypeMismatchException(MethodArgumentTypeMismatchException e) {
+    log.error("handleMethodArgumentTypeMismatchException", e);
+    final ErrorResponse response = ErrorResponse.of(e);
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  /**
+   * 지원하지 않은 HTTP method 호출 할 경우 발생
+   */
+  @ExceptionHandler(HttpRequestMethodNotSupportedException.class)
+  protected ResponseEntity<ErrorResponse> handleHttpRequestMethodNotSupportedException(HttpRequestMethodNotSupportedException e) {
+    log.error("handleHttpRequestMethodNotSupportedException", e);
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.METHOD_NOT_ALLOWED);
+    return new ResponseEntity<>(response, HttpStatus.METHOD_NOT_ALLOWED);
+  }
+
+  /**
+   * Authentication 객체가 필요한 권한을 보유하지 않은 경우 발생합
+   */
+  @ExceptionHandler(AccessDeniedException.class)
+  protected ResponseEntity<ErrorResponse> handleAccessDeniedException(AccessDeniedException e) {
+    log.error("handleAccessDeniedException", e);
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.HANDLE_ACCESS_DENIED);
+    return new ResponseEntity<>(response, HttpStatus.valueOf(ErrorCode.HANDLE_ACCESS_DENIED.getStatus()));
+  }
+
+  @ExceptionHandler(BusinessException.class)
+  protected ResponseEntity<ErrorResponse> handleBusinessException(final BusinessException e) {
+    log.error("Exception : {}, Massage : {}", e.getClass(), e.getMessage());
+    final ErrorCode errorCode = e.getErrorCode();
+    final ErrorResponse response = ErrorResponse.of(errorCode);
+    return new ResponseEntity<>(response, HttpStatus.valueOf(errorCode.getStatus()));
+  }
+
+
+  @ExceptionHandler(Exception.class)
+  protected ResponseEntity<ErrorResponse> handleException(Exception e) {
+    log.error("Exception : {}, Massage : {}", e.getClass(), e.getMessage());
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.INTERNAL_SERVER_ERROR);
+    return new ResponseEntity<>(response, HttpStatus.INTERNAL_SERVER_ERROR);
+  }
+}

--- a/src/main/java/com/noti/noti/error/exception/BusinessException.java
+++ b/src/main/java/com/noti/noti/error/exception/BusinessException.java
@@ -1,0 +1,21 @@
+package com.noti.noti.error.exception;
+
+import com.noti.noti.error.ErrorCode;
+
+public class BusinessException extends RuntimeException{
+  private ErrorCode errorCode;
+
+  public BusinessException(String message, ErrorCode errorCode) {
+    super(message);
+    this.errorCode = errorCode;
+  }
+
+  public BusinessException(ErrorCode errorCode) {
+    super(errorCode.getMessage());
+    this.errorCode = errorCode;
+  }
+
+  public ErrorCode getErrorCode() {
+    return errorCode;
+  }
+}

--- a/src/main/java/com/noti/noti/error/exception/EntityNotFoundException.java
+++ b/src/main/java/com/noti/noti/error/exception/EntityNotFoundException.java
@@ -1,0 +1,14 @@
+package com.noti.noti.error.exception;
+
+import com.noti.noti.error.ErrorCode;
+
+public class EntityNotFoundException extends BusinessException{
+
+  public EntityNotFoundException(String message) {
+    super(message, ErrorCode.ENTITY_NOT_FOUND);
+  }
+
+  public EntityNotFoundException(String message, ErrorCode errorCode) {
+    super(message, errorCode);
+  }
+}

--- a/src/main/java/com/noti/noti/error/exception/InvalidValueException.java
+++ b/src/main/java/com/noti/noti/error/exception/InvalidValueException.java
@@ -1,0 +1,15 @@
+package com.noti.noti.error.exception;
+
+import com.noti.noti.error.ErrorCode;
+import com.noti.noti.error.exception.BusinessException;
+
+public class InvalidValueException extends BusinessException {
+
+  public InvalidValueException(String message, ErrorCode errorCode) {
+    super(message, errorCode);
+  }
+
+  public InvalidValueException(String message) {
+    super(message, ErrorCode.INVALID_INPUT_VALUE);
+  }
+}

--- a/src/main/java/com/noti/noti/student/exception/StudentNotFoundException.java
+++ b/src/main/java/com/noti/noti/student/exception/StudentNotFoundException.java
@@ -1,0 +1,11 @@
+package com.noti.noti.student.exception;
+
+import com.noti.noti.error.ErrorCode;
+import com.noti.noti.error.exception.EntityNotFoundException;
+
+public class StudentNotFoundException extends EntityNotFoundException {
+
+  public StudentNotFoundException(Long id) {
+    super("학생 ID: "+ id, ErrorCode.STUDENT_NOT_FOUND);
+  }
+}


### PR DESCRIPTION
## 예외처리 로직 구현

- ErrorCode Enum 클래스 : Error status, code, message를 담는 이넘 클래스 공통 에러들 정의 해놓았고 도메인에 대한 예외 작성하시면됩니다.
- BusinessException, NotFoundEntityException, InvalidValueException : 앞으로 정의할 예외들의 공통 부모 클래스, 해당 예외가 발생하면 상속해서 사용하시면 됩니다. ex)StudentNotFoundException 구현부 참고 부탁드려요.
- GlobalExceptionHandler : 예외를 핸들링할 Global advice 예외가 발생하면 advice에서 인터셉트해 예외 응답을 내려줍니다. 