### PR TITLE
Feature/noti 58 교재 조회 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -38,3 +38,5 @@ out/
 ### VS Code ###
 .vscode/
 src/main/resources/**.yaml
+
+.jqwik-database

--- a/build.gradle
+++ b/build.gradle
@@ -70,6 +70,9 @@ dependencies {
 	testImplementation 'org.testcontainers:testcontainers:1.17.5'
 	testImplementation 'org.testcontainers:junit-jupiter:1.17.5'
 	testImplementation 'org.testcontainers:mysql:1.17.5'
+
+	// 테스트 객체 생성을 위한 Fixture-monkey 추가
+ 	testImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:0.4.12'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/noti/noti/book/adapter/in/web/controller/GetAllBooksController.java
+++ b/src/main/java/com/noti/noti/book/adapter/in/web/controller/GetAllBooksController.java
@@ -1,0 +1,31 @@
+package com.noti.noti.book.adapter.in.web.controller;
+
+import com.noti.noti.book.adapter.in.web.response.GetAllBooksResponse;
+import com.noti.noti.book.application.port.in.GetAllBooksQuery;
+import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class GetAllBooksController {
+
+  private final GetAllBooksQuery getAllBooksQuery;
+
+  @GetMapping("/api/teacher/books")
+  public ResponseEntity getAllBooks(@AuthenticationPrincipal UserDetails userDetails) {
+    long teacherId = Long.parseLong(userDetails.getUsername());
+
+    List<GetAllBooksResponse> response = new ArrayList<>();
+    getAllBooksQuery.getAllBooks(teacherId)
+        .forEach(bookDto -> response.add(GetAllBooksResponse.from(bookDto)));
+
+    return ResponseEntity.ok(SuccessResponse.create200SuccessResponse(response));
+  }
+}

--- a/src/main/java/com/noti/noti/book/adapter/in/web/response/GetAllBooksResponse.java
+++ b/src/main/java/com/noti/noti/book/adapter/in/web/response/GetAllBooksResponse.java
@@ -1,0 +1,20 @@
+package com.noti.noti.book.adapter.in.web.response;
+
+import com.noti.noti.book.application.port.out.BookDto;
+import lombok.Getter;
+
+@Getter
+public class GetAllBooksResponse {
+
+  private Long id;
+  private String title;
+
+  private GetAllBooksResponse(Long id, String title) {
+    this.id = id;
+    this.title = title;
+  }
+
+  public static GetAllBooksResponse from(BookDto book) {
+    return new GetAllBooksResponse(book.getId(), book.getTitle());
+  }
+}

--- a/src/main/java/com/noti/noti/book/adapter/out/persistence/BookPersistenceAdapter.java
+++ b/src/main/java/com/noti/noti/book/adapter/out/persistence/BookPersistenceAdapter.java
@@ -1,10 +1,12 @@
 package com.noti.noti.book.adapter.out.persistence;
 
 import com.noti.noti.book.adapter.out.persistence.jpa.BookJpaRepository;
+import com.noti.noti.book.application.port.out.BookDto;
 import com.noti.noti.book.application.port.out.FindBookCondition;
 import com.noti.noti.book.application.port.out.FindBookPort;
 import com.noti.noti.book.application.port.out.SaveBookPort;
 import com.noti.noti.book.domain.model.Book;
+import java.util.List;
 import java.util.Optional;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Component;
@@ -32,6 +34,11 @@ public class BookPersistenceAdapter implements SaveBookPort, FindBookPort {
   @Override
   public Optional<Book> findBookByTitle(String title) {
     return bookJpaRepository.findByTitle(title).map(bookMapper::mapToDomainEntity);
+  }
+
+  @Override
+  public List<BookDto> findBooksByTeacherId(Long teacherId) {
+    return bookQueryRepository.findAllBooksByTeacherId(teacherId);
   }
 
   @Override

--- a/src/main/java/com/noti/noti/book/adapter/out/persistence/BookQueryRepository.java
+++ b/src/main/java/com/noti/noti/book/adapter/out/persistence/BookQueryRepository.java
@@ -2,9 +2,12 @@ package com.noti.noti.book.adapter.out.persistence;
 
 import static com.noti.noti.book.adapter.out.persistence.jpa.model.QBookJpaEntity.bookJpaEntity;
 
+import com.noti.noti.book.application.port.out.BookDto;
 import com.noti.noti.book.application.port.out.FindBookCondition;
+import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.jpa.impl.JPAQueryFactory;
+import java.util.List;
 import java.util.Objects;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Repository;
@@ -24,6 +27,20 @@ public class BookQueryRepository {
         .fetchOne();
 
     return result != null;
+  }
+
+  /**
+   * teacerId에 해당하는 모든 교재 조회
+   *
+   * @param teacherId
+   * @return
+   */
+  List<BookDto> findAllBooksByTeacherId(Long teacherId) {
+    return jpaQueryFactory
+        .select(Projections.fields(BookDto.class, bookJpaEntity.id, bookJpaEntity.title))
+        .from(bookJpaEntity)
+        .where(eqTeacherId(teacherId))
+        .fetch();
   }
 
   private BooleanExpression eqTitle(String title) {

--- a/src/main/java/com/noti/noti/book/application/port/in/GetAllBooksQuery.java
+++ b/src/main/java/com/noti/noti/book/application/port/in/GetAllBooksQuery.java
@@ -1,0 +1,13 @@
+package com.noti.noti.book.application.port.in;
+
+import com.noti.noti.book.application.port.out.BookDto;
+import java.util.List;
+
+/**
+ * @author 임호준
+ * @description 선생님의 모든 교재를 조회하기 위한 interface
+ */
+public interface GetAllBooksQuery {
+
+  List<BookDto> getAllBooks(Long teacherId);
+}

--- a/src/main/java/com/noti/noti/book/application/port/out/BookDto.java
+++ b/src/main/java/com/noti/noti/book/application/port/out/BookDto.java
@@ -1,0 +1,10 @@
+package com.noti.noti.book.application.port.out;
+
+import lombok.Getter;
+
+@Getter
+public class BookDto {
+
+  private Long id;
+  private String title;
+}

--- a/src/main/java/com/noti/noti/book/application/port/out/FindBookPort.java
+++ b/src/main/java/com/noti/noti/book/application/port/out/FindBookPort.java
@@ -1,6 +1,7 @@
 package com.noti.noti.book.application.port.out;
 
 import com.noti.noti.book.domain.model.Book;
+import java.util.List;
 import java.util.Optional;
 
 public interface FindBookPort {
@@ -8,6 +9,8 @@ public interface FindBookPort {
   Optional<Book> findBookById(Long id);
 
   Optional<Book> findBookByTitle(String title);
+
+  List<BookDto> findBooksByTeacherId(Long teacherId);
 
   boolean isExistedBook(FindBookCondition condition);
 }

--- a/src/main/java/com/noti/noti/book/application/service/GetAllBooksService.java
+++ b/src/main/java/com/noti/noti/book/application/service/GetAllBooksService.java
@@ -1,0 +1,35 @@
+package com.noti.noti.book.application.service;
+
+import com.noti.noti.book.application.port.in.GetAllBooksQuery;
+import com.noti.noti.book.application.port.out.BookDto;
+import com.noti.noti.book.application.port.out.FindBookPort;
+import com.noti.noti.teacher.application.exception.TeacherNotFoundException;
+import com.noti.noti.teacher.application.port.out.FindTeacherPort;
+import com.noti.noti.teacher.domain.Teacher;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 선생님의 모든 교재목록 조회 Service
+ * @author 임호준
+ */
+@Service
+@RequiredArgsConstructor
+public class GetAllBooksService implements GetAllBooksQuery {
+
+  private final FindTeacherPort findTeacherPort;
+  private final FindBookPort findBookPort;
+
+  @Transactional(readOnly = true)
+  @Override
+  public List<BookDto> getAllBooks(Long teacherId) {
+    Teacher foundTeacher = findTeacher(teacherId);
+    return findBookPort.findBooksByTeacherId(foundTeacher.getId());
+  }
+
+  private Teacher findTeacher(Long teacherId) {
+    return findTeacherPort.findById(teacherId).orElseThrow(TeacherNotFoundException::new);
+  }
+}

--- a/src/main/java/com/noti/noti/book/domain/model/Book.java
+++ b/src/main/java/com/noti/noti/book/domain/model/Book.java
@@ -9,7 +9,6 @@ public class Book {
 
   private Long id;
   private String title;
-
   private Teacher teacher;
 
   @Builder

--- a/src/main/java/com/noti/noti/book/domain/model/Book.java
+++ b/src/main/java/com/noti/noti/book/domain/model/Book.java
@@ -3,8 +3,10 @@ package com.noti.noti.book.domain.model;
 import com.noti.noti.teacher.domain.Teacher;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class Book {
 
   private Long id;

--- a/src/test/java/com/noti/noti/auth/adapter/in/web/controller/SignUpControllerTest.java
+++ b/src/test/java/com/noti/noti/auth/adapter/in/web/controller/SignUpControllerTest.java
@@ -10,7 +10,6 @@ import com.noti.noti.auth.application.port.in.SignUpCommand;
 import com.noti.noti.auth.application.port.in.SignUpUsecase;
 import com.noti.noti.auth.domain.JwtToken;
 import com.noti.noti.config.JacksonConfiguration;
-import com.noti.noti.config.security.jwt.JwtTokenProvider;
 import com.noti.noti.teacher.adpater.in.web.dto.OAuthInfo;
 import com.noti.noti.teacher.domain.SocialType;
 import org.junit.jupiter.api.BeforeEach;
@@ -27,12 +26,11 @@ import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.setup.MockMvcBuilders;
 import org.springframework.web.filter.CharacterEncodingFilter;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
 @ExtendWith(MockitoExtension.class)
 @DisplayName("SignUpControllerTest 클래스")
 @DisplayNameGeneration(ReplaceUnderscores.class)
-@Import({JacksonConfiguration.class, ObjectMapper.class, JwtTokenProvider.class})
+@Import(JacksonConfiguration.class)
 class SignUpControllerTest {
 
   private MockMvc mockMvc;

--- a/src/test/java/com/noti/noti/book/adapter/in/web/controller/AddBookControllerTest.java
+++ b/src/test/java/com/noti/noti/book/adapter/in/web/controller/AddBookControllerTest.java
@@ -17,6 +17,7 @@ import com.noti.noti.common.WithAuthUser;
 import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
 import com.noti.noti.config.JacksonConfiguration;
 import com.noti.noti.config.security.jwt.JwtTokenProvider;
+import com.noti.noti.config.security.jwt.filter.CustomJwtFilter;
 import com.noti.noti.teacher.application.exception.TeacherNotFoundException;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -26,15 +27,18 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
-@WebMvcTest(AddBookController.class)
+@WebMvcTest(controllers = AddBookController.class,
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE, classes = CustomJwtFilter.class))
 @DisplayName("AddBookController 클래스")
 @DisplayNameGeneration(ReplaceUnderscores.class)
-@Import({JacksonConfiguration.class, ObjectMapper.class, JwtTokenProvider.class})
+@Import(JacksonConfiguration.class)
 class AddBookControllerTest {
 
   @Autowired

--- a/src/test/java/com/noti/noti/book/adapter/in/web/controller/GetAllBooksControllerTest.java
+++ b/src/test/java/com/noti/noti/book/adapter/in/web/controller/GetAllBooksControllerTest.java
@@ -1,0 +1,99 @@
+package com.noti.noti.book.adapter.in.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.noti.noti.book.application.port.in.GetAllBooksQuery;
+import com.noti.noti.book.application.port.out.BookDto;
+import com.noti.noti.common.MonkeyUtils;
+import com.noti.noti.common.WithAuthUser;
+import com.noti.noti.config.JacksonConfiguration;
+import com.noti.noti.config.security.jwt.filter.CustomJwtFilter;
+import com.noti.noti.teacher.application.exception.TeacherNotFoundException;
+import java.util.List;
+import net.jqwik.api.Arbitraries;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = GetAllBooksController.class,
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE, classes = CustomJwtFilter.class))
+@DisplayName("GetAllBooksController 클래스")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Import(JacksonConfiguration.class)
+class GetAllBooksControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @MockBean
+  GetAllBooksQuery getAllBooksQuery;
+
+  @WithAuthUser(id = "1", role = "ROLE_TEACHER")
+  @Nested
+  class getAllBooks_메서드는 {
+
+    @Nested
+    class 요청에_해당하는_교재_정보가_존재하지_않으면 {
+
+      @Test
+      void 비어있는_Response_List를_반환한다() throws Exception {
+        when(getAllBooksQuery.getAllBooks(anyLong())).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/teacher/books"))
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.data").isEmpty()
+            );
+      }
+    }
+
+    @Nested
+    class 요청에_해당하는_교재_정보가_존재하면 {
+
+      @Test
+      void 교재_정보가_담긴_Response_List를_반환한다() throws Exception {
+        List<BookDto> givenBookDtos = MonkeyUtils.MONKEY.giveMeBuilder(BookDto.class)
+            .set("id", Arbitraries.longs().greaterOrEqual(1L))
+            .setNotNull("title")
+            .sampleList(5);
+
+        when(getAllBooksQuery.getAllBooks(anyLong())).thenReturn(givenBookDtos);
+        mockMvc.perform(get("/api/teacher/books"))
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.data").isNotEmpty()
+            );
+      }
+    }
+
+    @Nested
+    class 요청에_해당하는_선생_정보가_존재하지_않으면 {
+
+      @Test
+      void TeacherNotFoundException_예외가_발생하고_404_응답을_반환한다() throws Exception {
+        when(getAllBooksQuery.getAllBooks(anyLong())).thenThrow(new TeacherNotFoundException());
+        mockMvc.perform(get("/api/teacher/books"))
+            .andExpectAll(
+                status().isNotFound(),
+                result -> assertThat(result.getResolvedException()).isInstanceOf(
+                    TeacherNotFoundException.class)
+            );
+      }
+    }
+  }
+}

--- a/src/test/java/com/noti/noti/book/adapter/out/persistence/BookPersistenceAdapterTest.java
+++ b/src/test/java/com/noti/noti/book/adapter/out/persistence/BookPersistenceAdapterTest.java
@@ -2,11 +2,13 @@ package com.noti.noti.book.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
+import com.noti.noti.book.application.port.out.BookDto;
 import com.noti.noti.book.application.port.out.FindBookCondition;
 import com.noti.noti.book.domain.model.Book;
 import com.noti.noti.config.QuerydslTestConfig;
 import com.noti.noti.teacher.adpater.out.persistence.TeacherMapper;
 import com.noti.noti.teacher.domain.Teacher;
+import java.util.List;
 import java.util.Optional;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -29,6 +31,8 @@ class BookPersistenceAdapterTest {
 
   @Autowired
   BookPersistenceAdapter bookPersistenceAdapter;
+
+  final Long TEACHER_ID = 1L;
 
   @Nested
   class FindBookById_메서드는 {
@@ -60,6 +64,7 @@ class BookPersistenceAdapterTest {
     }
   }
 
+  @Sql("/data/teacher.sql")
   @Nested
   class saveBook_메서드는 {
 
@@ -98,6 +103,33 @@ class BookPersistenceAdapterTest {
         boolean result = bookPersistenceAdapter.isExistedBook(createCondition("수학의정석", 2L));
 
         assertThat(result).isFalse();
+      }
+    }
+  }
+
+  @Nested
+  class findBooksByTeacherId_메서드는 {
+
+    @Nested
+    class 선생님_ID에_해당하는_교재가_있다면 {
+
+      @Sql("/data/book.sql")
+      @Test
+      void 해당_BookDto_List_를_반환한다() {
+        List<BookDto> books = bookPersistenceAdapter.findBooksByTeacherId(TEACHER_ID);
+
+        assertThat(books).isNotEmpty();
+      }
+    }
+
+    @Nested
+    class 선생님_ID에_해당하는_교재가_없다면 {
+
+      @Test
+      void 해당_비어있는_List_를_반환한다() {
+        List<BookDto> books = bookPersistenceAdapter.findBooksByTeacherId(TEACHER_ID);
+
+        assertThat(books).isEmpty();
       }
     }
   }

--- a/src/test/java/com/noti/noti/book/application/service/GetAllBooksServiceTest.java
+++ b/src/test/java/com/noti/noti/book/application/service/GetAllBooksServiceTest.java
@@ -1,0 +1,92 @@
+package com.noti.noti.book.application.service;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.noti.noti.book.application.port.out.BookDto;
+import com.noti.noti.book.application.port.out.FindBookPort;
+import com.noti.noti.common.MonkeyUtils;
+import com.noti.noti.teacher.application.exception.TeacherNotFoundException;
+import com.noti.noti.teacher.application.port.out.FindTeacherPort;
+import java.util.List;
+import java.util.Optional;
+import net.jqwik.api.Arbitraries;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class GetAllBooksServiceTest {
+
+  @InjectMocks
+  GetAllBooksService getAllBooksService;
+  @Mock
+  FindTeacherPort findTeacherPort;
+  @Mock
+  FindBookPort findBookPort;
+
+
+  @Nested
+  class _메서드는 {
+
+    @Nested
+    class 선생님_ID에_해당하는_교재가_있으면 {
+
+      @Test
+      void 해당_BookDto_List를_반환한다() {
+        List<BookDto> givenBookDtos = MonkeyUtils.MONKEY.giveMeBuilder(BookDto.class)
+            .set("id", Arbitraries.longs().greaterOrEqual(1L))
+            .sampleList(5);
+
+        when(findTeacherPort.findById(anyLong())).thenReturn(
+            Optional.of(MonkeyUtils.TEACHER_FIXTURE));
+        when(findBookPort.findBooksByTeacherId(anyLong())).thenReturn(givenBookDtos);
+
+        List<BookDto> books = getAllBooksService.getAllBooks(1L);
+
+        assertThat(books.size()).isEqualTo(5);
+      }
+    }
+
+    @Nested
+    class 선생님_ID에_해당하는_교재가_없으면 {
+
+      @Test
+      void 비어있는_List을_반환한다() {
+        when(findTeacherPort.findById(anyLong())).thenReturn(
+            Optional.of(MonkeyUtils.TEACHER_FIXTURE));
+        when(findBookPort.findBooksByTeacherId(anyLong())).thenReturn(List.of());
+
+        List<BookDto> books = getAllBooksService.getAllBooks(1L);
+
+        assertThat(books).isEmpty();
+      }
+    }
+
+    @Nested
+    class ID에_해당하는_선생님이_존재하지_않으면 {
+
+      @Test
+      void TeacherNotFoundException_예외가_발생한다() {
+        when(findTeacherPort.findById(anyLong())).thenReturn(Optional.empty());
+
+        assertAll(
+            () -> assertThatThrownBy(() -> getAllBooksService.getAllBooks(1L))
+                .isInstanceOf(TeacherNotFoundException.class),
+            () -> verify(findBookPort, never()).findBooksByTeacherId(anyLong())
+        );
+      }
+    }
+  }
+}

--- a/src/test/java/com/noti/noti/common/MonkeyUtils.java
+++ b/src/test/java/com/noti/noti/common/MonkeyUtils.java
@@ -1,0 +1,26 @@
+package com.noti.noti.common;
+
+import com.navercorp.fixturemonkey.FixtureMonkey;
+import com.navercorp.fixturemonkey.LabMonkey;
+import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.noti.noti.teacher.domain.Role;
+import com.noti.noti.teacher.domain.Teacher;
+
+/**
+ * @author 임호준
+ * @description Fixture-Monkey를 사용하기 위한 싱글턴 Util 클래스
+ */
+public class MonkeyUtils {
+
+  public static final FixtureMonkey MONKEY = monkey();
+  public static final Teacher TEACHER_FIXTURE = Teacher.builder().id(1L).nickname("NOTI")
+      .role(Role.ROLE_TEACHER).build();
+
+  private MonkeyUtils() {}
+  private static FixtureMonkey monkey() {
+    return LabMonkey.labMonkeyBuilder()
+        .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
+        .build();
+  }
+
+}

--- a/src/test/java/com/noti/noti/lesson/adapter/in/web/controller/AddLessonControllerTest.java
+++ b/src/test/java/com/noti/noti/lesson/adapter/in/web/controller/AddLessonControllerTest.java
@@ -14,7 +14,7 @@ import com.noti.noti.book.exception.BookNotFoundException;
 import com.noti.noti.common.WithAuthUser;
 import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
 import com.noti.noti.config.JacksonConfiguration;
-import com.noti.noti.config.security.jwt.JwtTokenProvider;
+import com.noti.noti.config.security.jwt.filter.CustomJwtFilter;
 import com.noti.noti.lesson.application.port.in.AddLessonCommand;
 import com.noti.noti.lesson.application.port.in.AddLessonUsecase;
 import com.noti.noti.lesson.domain.model.Lesson;
@@ -28,16 +28,19 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.http.MediaType;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.web.bind.MethodArgumentNotValidException;
-import org.testcontainers.shaded.com.fasterxml.jackson.databind.ObjectMapper;
 
-@WebMvcTest(AddLessonController.class)
+@WebMvcTest(controllers = AddLessonController.class,
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE, classes = CustomJwtFilter.class))
 @DisplayName("AddLessonControllerTest 클래스")
 @DisplayNameGeneration(ReplaceUnderscores.class)
-@Import({JacksonConfiguration.class, ObjectMapper.class, JwtTokenProvider.class})
+@Import(JacksonConfiguration.class)
 class AddLessonControllerTest {
 
   @Autowired

--- a/src/test/java/com/noti/noti/lesson/adapter/in/web/controller/GetCreatedLessonsControllerTest.java
+++ b/src/test/java/com/noti/noti/lesson/adapter/in/web/controller/GetCreatedLessonsControllerTest.java
@@ -5,7 +5,7 @@ import static org.mockito.ArgumentMatchers.any;
 import com.noti.noti.common.WithAuthUser;
 import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
 import com.noti.noti.config.JacksonConfiguration;
-import com.noti.noti.config.security.jwt.JwtTokenProvider;
+import com.noti.noti.config.security.jwt.filter.CustomJwtFilter;
 import com.noti.noti.lesson.application.port.in.CreatedLessonCommand;
 import com.noti.noti.lesson.application.port.in.GetCreatedLessonsQuery;
 import com.noti.noti.lesson.application.port.in.InCreatedLesson;
@@ -20,6 +20,8 @@ import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -28,14 +30,13 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 @DisplayName("GetCreatedLessonsControllerTest 클래스")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @Import(JacksonConfiguration.class)
-@WebMvcTest(GetCreatedLessonsController.class)
+@WebMvcTest(controllers = GetCreatedLessonsController.class,
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE, classes = CustomJwtFilter.class))
 class GetCreatedLessonsControllerTest {
 
   @Autowired
   private MockMvc mockMvc;
-
-  @MockBean
-  private JwtTokenProvider jwtTokenProvider;
 
   @MockBean
   private GetCreatedLessonsQuery getCreatedLessonsQuery;

--- a/src/test/java/com/noti/noti/lesson/adapter/in/web/controller/GetFrequencyOfLessonsControllerTest.java
+++ b/src/test/java/com/noti/noti/lesson/adapter/in/web/controller/GetFrequencyOfLessonsControllerTest.java
@@ -6,8 +6,7 @@ import static org.mockito.Mockito.when;
 import com.noti.noti.common.WithAuthUser;
 import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
 import com.noti.noti.config.JacksonConfiguration;
-import com.noti.noti.config.security.jwt.JwtTokenProvider;
-import com.noti.noti.lesson.adapter.in.web.dto.response.FrequencyOfLessonsDto;
+import com.noti.noti.config.security.jwt.filter.CustomJwtFilter;
 import com.noti.noti.lesson.application.port.in.DateFrequencyOfLessons;
 import com.noti.noti.lesson.application.port.in.GetFrequencyOfLessonsQuery;
 import java.time.LocalDate;
@@ -20,6 +19,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
@@ -29,14 +30,13 @@ import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 @DisplayName("GetFrequencyOfLessonsControllerTest 클래스")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @Import(JacksonConfiguration.class)
-@WebMvcTest(GetFrequencyOfLessonsController.class)
+@WebMvcTest(controllers = GetFrequencyOfLessonsController.class,
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE, classes = CustomJwtFilter.class))
 class GetFrequencyOfLessonsControllerTest {
 
   @Autowired
   private MockMvc mockMvc;
-
-  @MockBean
-  private JwtTokenProvider jwtTokenProvider;
 
   @MockBean
   private GetFrequencyOfLessonsQuery getFrequencyOfLessonsQuery;

--- a/src/test/java/com/noti/noti/lesson/adapter/in/web/controller/GetTodaysLessonInfoControllerTest.java
+++ b/src/test/java/com/noti/noti/lesson/adapter/in/web/controller/GetTodaysLessonInfoControllerTest.java
@@ -3,13 +3,12 @@ package com.noti.noti.lesson.adapter.in.web.controller;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.*;
-import static org.springframework.test.web.servlet.result.MockMvcResultHandlers.print;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
 import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
 
 import com.noti.noti.common.WithAuthUser;
 import com.noti.noti.config.JacksonConfiguration;
-import com.noti.noti.config.security.jwt.JwtTokenProvider;
+import com.noti.noti.config.security.jwt.filter.CustomJwtFilter;
 import com.noti.noti.homework.application.port.out.TodaysHomework;
 import com.noti.noti.homework.application.port.out.TodaysHomework.HomeworkOfStudent;
 import com.noti.noti.lesson.application.port.in.GetTodaysLessonQuery;
@@ -30,11 +29,15 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 
 
-@WebMvcTest(GetTodaysLessonInfoController.class)
+@WebMvcTest(controllers = GetTodaysLessonInfoController.class,
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE, classes = CustomJwtFilter.class))
 @DisplayName("GetTodaysLessonInfoControllerTest 클래스")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @Import(JacksonConfiguration.class)
@@ -42,9 +45,6 @@ class GetTodaysLessonInfoControllerTest {
 
   @Autowired
   private MockMvc mockMvc;
-
-  @MockBean
-  private JwtTokenProvider jwtTokenProvider;
 
   @MockBean
   private GetTodaysLessonQuery getTodaysLessonQuery;
@@ -151,8 +151,7 @@ class GetTodaysLessonInfoControllerTest {
             .andExpect(status().isOk())
             .andExpect(jsonPath("$.data.teacherNickName").value(TEACHER_NAME))
             .andExpect(jsonPath("$.data.isLessonCreated").value(true))
-            .andExpect(jsonPath("$.data.lessons.length()").value(3))
-            .andDo(print());
+            .andExpect(jsonPath("$.data.lessons.length()").value(3));
       }
     }
 
@@ -201,8 +200,7 @@ class GetTodaysLessonInfoControllerTest {
             .andExpect(jsonPath("$.data.teacherNickName").value(TEACHER_NAME))
             .andExpect(jsonPath("$.data.isLessonCreated").value(true))
             .andExpect(jsonPath("$.data.lessons.length()").value(3))
-            .andExpect(jsonPath("$.data.lessons[0].students.length()").value(3))
-            .andDo(print());
+            .andExpect(jsonPath("$.data.lessons[0].students.length()").value(3));
       }
     }
 
@@ -255,8 +253,7 @@ class GetTodaysLessonInfoControllerTest {
             .andExpect(jsonPath("$.data.teacherNickName").value(TEACHER_NAME))
             .andExpect(jsonPath("$.data.isLessonCreated").value(true))
             .andExpect(jsonPath("$.data.lessons.length()").value(3))
-            .andExpect(jsonPath("$.data.lessons[0].homeworkCompletionRate").value(33))
-            .andDo(print());
+            .andExpect(jsonPath("$.data.lessons[0].homeworkCompletionRate").value(33));
       }
     }
   }

--- a/src/test/java/com/noti/noti/studenthomework/adapter/in/web/controller/GetHomeworksOfCalendarControllerTest.java
+++ b/src/test/java/com/noti/noti/studenthomework/adapter/in/web/controller/GetHomeworksOfCalendarControllerTest.java
@@ -6,7 +6,7 @@ import static org.mockito.Mockito.when;
 
 import com.noti.noti.common.WithAuthUser;
 import com.noti.noti.config.JacksonConfiguration;
-import com.noti.noti.config.security.jwt.JwtTokenProvider;
+import com.noti.noti.config.security.jwt.filter.CustomJwtFilter;
 import com.noti.noti.studenthomework.application.port.in.GetHomeworksOfCalendarQuery;
 import com.noti.noti.studenthomework.application.port.in.InHomeworkOfGivenDate;
 import com.noti.noti.studenthomework.application.port.out.OutHomeworkOfGivenDate;
@@ -20,12 +20,16 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
 import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
 import org.springframework.context.annotation.Import;
 import org.springframework.test.web.servlet.MockMvc;
 import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
 import org.springframework.test.web.servlet.result.MockMvcResultMatchers;
 
-@WebMvcTest(GetHomeworksOfCalendarController.class)
+@WebMvcTest(controllers = GetHomeworksOfCalendarController.class,
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE, classes = CustomJwtFilter.class))
 @Import(JacksonConfiguration.class)
 @DisplayNameGeneration(ReplaceUnderscores.class)
 class GetHomeworksOfCalendarControllerTest {
@@ -35,9 +39,6 @@ class GetHomeworksOfCalendarControllerTest {
 
   @MockBean
   GetHomeworksOfCalendarQuery getHomeworksOfCalendarQuery;
-
-  @MockBean
-  JwtTokenProvider provider;
 
   List<InHomeworkOfGivenDate> createHomeworkOfCalendar() {
 

--- a/src/test/java/com/noti/noti/studenthomework/adapter/out/persistence/StudentHomeworkAdapterTest.java
+++ b/src/test/java/com/noti/noti/studenthomework/adapter/out/persistence/StudentHomeworkAdapterTest.java
@@ -1,7 +1,6 @@
 package com.noti.noti.studenthomework.adapter.out.persistence;
 
 import com.noti.noti.config.QuerydslTestConfig;
-import com.noti.noti.studenthomework.adapter.in.web.dto.response.HomeworkOfGivenDateDto;
 import com.noti.noti.studenthomework.application.port.out.OutHomeworkOfGivenDate;
 import java.time.LocalDate;
 import java.util.List;


### PR DESCRIPTION
선생님의 모든 교재를 조회하는 기능을 구현했습니다.
구현 과정에서 Book의 teacherJpaEntity를 도메인 모델로 매핑하는 과정에서 LazyLoading 문제가 생겨 이를 해결하기 위해 
여러가지 방법이 있지만 querydsl을 이용해 BookDto를 반환하는 방법으로 구현했습니다.

단위테스트코드 작성 과정에서 객체 생성에 대한 코드가 테스트마다 반복되어서 Fixture-Monkey 를 사용했습니다. 
깃헙과 블로그: [Fixture-Monkey Github], [블로그] 를 참고하시면 좋을거 같아요.
FixtureMonkey 객체는 싱글턴으로 재사용 할 수 있게 MonKeyUtils에 구현해 놓았습니다. 무조건 사용해야된다는 아니니까 우선 편하신 방법으로 사용하면 진행하시면 될거같아요!!

WebMvcTest 에서 빈 주입과정에서 JwtProvider 부분에서 문제가 생기는 부분을 해결하고 필요없는 import 들 다 지웠습니다. 원인은 스터디때 자세히 설명드릴게요!! : 413d03e84f5d0d5a65c20f8caacc04c094fd1bd1
원인과 해결에 대한 링크: 
   - https://spring.io/blog/2022/02/21/spring-security-without-the-websecurityconfigureradapter
   - https://github.com/spring-projects/spring-boot/issues/31162
   - https://docs.spring.io/spring-boot/docs/current/reference/htmlsingle/#howto.testing.slice-tests
   - https://docs.spring.io/spring-boot/docs/current/api/org/springframework/boot/test/autoconfigure/web/servlet/WebMvcTest.html

[Fixture-Monkey Github]: https://github.com/naver/fixture-monkey
[블로그]: https://velog.io/@pang_e/Fixture-Monkey%EB%9E%80