### PR TITLE
[FEAT] NOTI-60 선생님에 해당하는 모든 수업 조회 기능 구현

### DIFF
--- a/src/main/java/com/noti/noti/lesson/adapter/in/web/controller/GetAllLessonsController.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/in/web/controller/GetAllLessonsController.java
@@ -1,0 +1,32 @@
+package com.noti.noti.lesson.adapter.in.web.controller;
+
+import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
+import com.noti.noti.lesson.adapter.in.web.dto.response.GetAllLessonsResponse;
+import com.noti.noti.lesson.application.port.in.GetAllLessonsQuery;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+class GetAllLessonsController {
+
+  private final GetAllLessonsQuery getAllLessonsQuery;
+
+  @GetMapping("/api/teacher/lessons")
+  public ResponseEntity<SuccessResponse<List<GetAllLessonsResponse>>> getAllLessons(
+      @AuthenticationPrincipal UserDetails userDetails){
+    Long teacherId = Long.valueOf(userDetails.getUsername());
+
+    ArrayList<GetAllLessonsResponse> response = new ArrayList<>();
+    getAllLessonsQuery.getAllLessons(teacherId).forEach(
+        lessonDto -> response.add(GetAllLessonsResponse.from(lessonDto)));
+
+    return ResponseEntity.ok().body(SuccessResponse.create200SuccessResponse(response));
+  }
+}

--- a/src/main/java/com/noti/noti/lesson/adapter/in/web/controller/GetAllLessonsController.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/in/web/controller/GetAllLessonsController.java
@@ -1,8 +1,14 @@
 package com.noti.noti.lesson.adapter.in.web.controller;
 
 import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
+import com.noti.noti.error.ErrorResponse;
 import com.noti.noti.lesson.adapter.in.web.dto.response.GetAllLessonsResponse;
 import com.noti.noti.lesson.application.port.in.GetAllLessonsQuery;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
@@ -18,6 +24,23 @@ class GetAllLessonsController {
 
   private final GetAllLessonsQuery getAllLessonsQuery;
 
+  @Operation(tags = "모든 수업 조회 API ", summary = "GetAllLessons", description = "모든 수업 목록 조회",
+      responses = {
+          @ApiResponse(responseCode = "200", description = "성공", useReturnTypeSchema = true),
+          @ApiResponse(responseCode = "500", description = "서버에러", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))}),
+          @ApiResponse(responseCode = "401", description = "인증되지 않은 유저입니다", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))}),
+          @ApiResponse(responseCode = "403", description = "권한이 없습니다", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))}),
+          @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스입니댜", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))})
+      })
+  @Parameter(name = "userDetails", hidden = true)
   @GetMapping("/api/teacher/lessons")
   public ResponseEntity<SuccessResponse<List<GetAllLessonsResponse>>> getAllLessons(
       @AuthenticationPrincipal UserDetails userDetails){

--- a/src/main/java/com/noti/noti/lesson/adapter/in/web/dto/response/GetAllLessonsResponse.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/in/web/dto/response/GetAllLessonsResponse.java
@@ -1,0 +1,32 @@
+package com.noti.noti.lesson.adapter.in.web.dto.response;
+
+import com.noti.noti.book.adapter.in.web.response.GetAllBooksResponse;
+import com.noti.noti.book.application.port.out.BookDto;
+import com.noti.noti.lesson.application.port.out.LessonDto;
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotNull;
+import lombok.Getter;
+
+@Getter
+@Schema(description = "모든 수업 조회 응답")
+public class GetAllLessonsResponse {
+  @Schema(description = "수업 ID", example = "1")
+  @NotNull
+  @Min(1)
+  private Long id;
+
+  @Schema(description = "수업명", example = "수학 기초반")
+  @NotBlank
+  private String lessonName;
+
+  private GetAllLessonsResponse(Long id, String lessonName) {
+    this.id = id;
+    this.lessonName = lessonName;
+  }
+
+  public static GetAllLessonsResponse from(LessonDto lesson) {
+    return new GetAllLessonsResponse(lesson.getId(), lesson.getLessonName());
+  }
+}

--- a/src/main/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapter.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapter.java
@@ -4,9 +4,10 @@ import com.noti.noti.lesson.adapter.out.persistence.jpa.LessonJpaRepository;
 import com.noti.noti.lesson.adapter.out.persistence.jpa.model.LessonJpaEntity;
 import com.noti.noti.lesson.application.port.out.OutCreatedLesson;
 import com.noti.noti.lesson.application.port.out.FindCreatedLessonsPort;
-import com.noti.noti.lesson.application.port.out.FindTodaysLessonPort;
+import com.noti.noti.lesson.application.port.out.FindLessonPort;
 import com.noti.noti.lesson.application.port.out.FrequencyOfLessons;
 import com.noti.noti.lesson.application.port.out.FrequencyOfLessonsPort;
+import com.noti.noti.lesson.application.port.out.LessonDto;
 import com.noti.noti.lesson.application.port.out.SaveLessonPort;
 import com.noti.noti.lesson.application.port.out.TodaysLesson;
 import com.noti.noti.lesson.application.port.out.TodaysLessonSearchConditon;
@@ -20,7 +21,7 @@ import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class LessonPersistenceAdapter implements SaveLessonPort, FindTodaysLessonPort,
+class LessonPersistenceAdapter implements SaveLessonPort, FindLessonPort,
     FrequencyOfLessonsPort, FindCreatedLessonsPort {
 
   private final LessonJpaRepository lessonJpaRepository;
@@ -40,6 +41,11 @@ public class LessonPersistenceAdapter implements SaveLessonPort, FindTodaysLesso
   }
 
   @Override
+  public List<LessonDto> findAllLessonsByTeacherId(Long teacherId) {
+    return lessonQueryRepository.findAllLessonsByTeacherId(teacherId);
+  }
+
+  @Override
   public List<FrequencyOfLessons> findFrequencyOfLessons(String yearMonth, Long teacherId) {
     LocalDateTime startTime = stringToLocalDateTime(yearMonth);
     LocalDateTime endTime = startTime.plusMonths(1);
@@ -53,6 +59,7 @@ public class LessonPersistenceAdapter implements SaveLessonPort, FindTodaysLesso
 
   /**
    * 문자열을 LocalDateTime으로 변환
+   *
    * @param yearMonth '년-월' 형식의 문자열
    * @return 해당 '년-월'에서 1일의 LocalDateTime
    */
@@ -64,7 +71,6 @@ public class LessonPersistenceAdapter implements SaveLessonPort, FindTodaysLesso
 
     return LocalDateTime.parse(stringBuilder, formatter);
   }
-
 
 
   @Override

--- a/src/main/java/com/noti/noti/lesson/adapter/out/persistence/LessonQueryRepository.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/out/persistence/LessonQueryRepository.java
@@ -9,6 +9,7 @@ import static com.querydsl.core.group.GroupBy.list;
 
 import com.noti.noti.lesson.application.port.out.FrequencyOfLessons;
 import com.noti.noti.lesson.application.port.out.OutCreatedLesson;
+import com.noti.noti.lesson.application.port.out.LessonDto;
 import com.noti.noti.lesson.application.port.out.TodaysLesson;
 import com.noti.noti.lesson.application.port.out.TodaysLessonSearchConditon;
 import com.querydsl.core.types.Projections;
@@ -23,16 +24,15 @@ import org.springframework.stereotype.Repository;
 @Slf4j
 @RequiredArgsConstructor
 @Repository
-public class LessonQueryRepository {
+class LessonQueryRepository {
 
   private final JPAQueryFactory queryFactory;
 
   /**
    * 선생님의 수업목록을 조회하는 메서드
-   * @param todaysLessonSearchConditon
-   * 선생님의 ID 조건
-   * @return
-   * 선생님의 수업목록과 수업에 해당하는 학생 목록
+   *
+   * @param todaysLessonSearchConditon 선생님의 ID 조건
+   * @return 선생님의 수업목록과 수업에 해당하는 학생 목록
    */
   public List<TodaysLesson> findTodayLesson(TodaysLessonSearchConditon todaysLessonSearchConditon) {
     return queryFactory
@@ -55,6 +55,22 @@ public class LessonQueryRepository {
                     studentJpaEntity.profileImage,
                     studentLessonJpaEntity.focusStatus).skipNulls()).as("students"))));
   }
+
+  /**
+   * 선생님에 해당하는 모든 수업 조회
+   *
+   * @param teacherId
+   * @return
+   */
+  List<LessonDto> findAllLessonsByTeacherId(Long teacherId) {
+    return queryFactory.select(Projections.fields(LessonDto.class,
+            lessonJpaEntity.id,
+            lessonJpaEntity.lessonName))
+        .from(lessonJpaEntity)
+        .where(eqTeacherId(teacherId))
+        .fetch();
+  }
+
 
   private BooleanExpression eqTeacherId(Long teacherId) {
     log.info("teacher Id: {} ", teacherId);
@@ -92,8 +108,6 @@ public class LessonQueryRepository {
         .from(lessonJpaEntity)
         .where(eqTeacherId(teacherId))
         .fetch();
-
-
   }
 
 }

--- a/src/main/java/com/noti/noti/lesson/application/port/in/GetAllLessonsQuery.java
+++ b/src/main/java/com/noti/noti/lesson/application/port/in/GetAllLessonsQuery.java
@@ -1,0 +1,9 @@
+package com.noti.noti.lesson.application.port.in;
+
+import com.noti.noti.lesson.application.port.out.LessonDto;
+import java.util.List;
+
+public interface GetAllLessonsQuery {
+
+  List<LessonDto> getAllLessons(Long teacherId);
+}

--- a/src/main/java/com/noti/noti/lesson/application/port/out/FindLessonPort.java
+++ b/src/main/java/com/noti/noti/lesson/application/port/out/FindLessonPort.java
@@ -1,0 +1,12 @@
+package com.noti.noti.lesson.application.port.out;
+
+import com.noti.noti.lesson.domain.model.Lesson;
+import java.util.List;
+import java.util.Optional;
+
+public interface FindLessonPort {
+
+  Optional<Lesson> findById(Long id);
+  List<TodaysLesson> findTodaysLessons(TodaysLessonSearchConditon condition);
+  List<LessonDto> findAllLessonsByTeacherId(Long teacherId);
+}

--- a/src/main/java/com/noti/noti/lesson/application/port/out/FindTodaysLessonPort.java
+++ b/src/main/java/com/noti/noti/lesson/application/port/out/FindTodaysLessonPort.java
@@ -1,8 +1,0 @@
-package com.noti.noti.lesson.application.port.out;
-
-import java.util.List;
-
-public interface FindTodaysLessonPort {
-
-  List<TodaysLesson> findTodaysLessons(TodaysLessonSearchConditon condition);
-}

--- a/src/main/java/com/noti/noti/lesson/application/port/out/LessonDto.java
+++ b/src/main/java/com/noti/noti/lesson/application/port/out/LessonDto.java
@@ -1,0 +1,10 @@
+package com.noti.noti.lesson.application.port.out;
+
+import lombok.Getter;
+
+@Getter
+public class LessonDto {
+
+  private Long id;
+  private String lessonName;
+}

--- a/src/main/java/com/noti/noti/lesson/application/service/GetAllLessonsService.java
+++ b/src/main/java/com/noti/noti/lesson/application/service/GetAllLessonsService.java
@@ -1,0 +1,34 @@
+package com.noti.noti.lesson.application.service;
+
+import com.noti.noti.lesson.application.port.in.GetAllLessonsQuery;
+import com.noti.noti.lesson.application.port.out.FindLessonPort;
+import com.noti.noti.lesson.application.port.out.LessonDto;
+import com.noti.noti.teacher.application.exception.TeacherNotFoundException;
+import com.noti.noti.teacher.application.port.out.FindTeacherPort;
+import com.noti.noti.teacher.domain.Teacher;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+@Service
+@RequiredArgsConstructor
+class GetAllLessonsService implements GetAllLessonsQuery {
+
+  private final FindTeacherPort findTeacherPort;
+  private final FindLessonPort findLessonPort;
+
+  @Transactional(readOnly = true)
+  @Override
+  public List<LessonDto> getAllLessons(Long teacherId) {
+    Teacher teacher = findTeacher(teacherId);
+    List<LessonDto> allLessons = findLessonPort.findAllLessonsByTeacherId(
+        teacher.getId());
+
+    return allLessons;
+  }
+
+  private Teacher findTeacher(Long teacherId) {
+    return findTeacherPort.findById(teacherId).orElseThrow(TeacherNotFoundException::new);
+  }
+}

--- a/src/main/java/com/noti/noti/lesson/application/service/GetTodaysLessonService.java
+++ b/src/main/java/com/noti/noti/lesson/application/service/GetTodaysLessonService.java
@@ -5,7 +5,7 @@ import com.noti.noti.homework.application.port.out.TodayHomeworkCondition;
 import com.noti.noti.homework.application.port.out.TodaysHomework;
 import com.noti.noti.lesson.application.port.in.GetTodaysLessonQuery;
 import com.noti.noti.lesson.application.port.in.TodaysLessonHomework;
-import com.noti.noti.lesson.application.port.out.FindTodaysLessonPort;
+import com.noti.noti.lesson.application.port.out.FindLessonPort;
 import com.noti.noti.lesson.application.port.out.TodaysLesson;
 import com.noti.noti.lesson.application.port.out.TodaysLessonSearchConditon;
 import com.noti.noti.teacher.application.port.out.FindTeacherNicknamePort;
@@ -20,7 +20,7 @@ import org.springframework.transaction.annotation.Transactional;
 @RequiredArgsConstructor
 public class GetTodaysLessonService implements GetTodaysLessonQuery {
 
-  private final FindTodaysLessonPort findTodaysLessonPort;
+  private final FindLessonPort findLessonPort;
   private final FindTodaysHomeworkPort findTodaysHomeworkPort;
   private final FindTeacherNicknamePort findTeacherNicknamePort;
 
@@ -31,7 +31,7 @@ public class GetTodaysLessonService implements GetTodaysLessonQuery {
     String teacherNickname = findTeacherNicknamePort.findTeacherNickname(teacherId);
     TodaysLessonHomework todaysLessonHomework = new TodaysLessonHomework(teacherNickname, now);
 
-    List<TodaysLesson> todaysLessons = findTodaysLessonPort.findTodaysLessons(
+    List<TodaysLesson> todaysLessons = findLessonPort.findTodaysLessons(
         new TodaysLessonSearchConditon(teacherId));
 
     addLesson(todaysLessonHomework, todaysLessons);

--- a/src/main/java/com/noti/noti/lesson/domain/model/Lesson.java
+++ b/src/main/java/com/noti/noti/lesson/domain/model/Lesson.java
@@ -11,7 +11,6 @@ import lombok.Getter;
 @Getter
 public class Lesson {
   private Long id;
-
   private Teacher teacher;
   private String lessonName;
   private Set<DayOfWeek> days;

--- a/src/test/java/com/noti/noti/lesson/adapter/in/web/controller/GetAllLessonsControllerTest.java
+++ b/src/test/java/com/noti/noti/lesson/adapter/in/web/controller/GetAllLessonsControllerTest.java
@@ -1,0 +1,100 @@
+package com.noti.noti.lesson.adapter.in.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.noti.noti.common.MonkeyUtils;
+import com.noti.noti.common.WithAuthUser;
+import com.noti.noti.config.JacksonConfiguration;
+import com.noti.noti.config.security.jwt.filter.CustomJwtFilter;
+import com.noti.noti.lesson.application.port.in.GetAllLessonsQuery;
+import com.noti.noti.lesson.application.port.out.LessonDto;
+import com.noti.noti.teacher.application.exception.TeacherNotFoundException;
+import java.util.List;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.get;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+@WebMvcTest(controllers = GetAllLessonsController.class,
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE, classes = CustomJwtFilter.class))
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Import(JacksonConfiguration.class)
+class GetAllLessonsControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @MockBean
+  GetAllLessonsQuery getAllLessonsQuery;
+
+  @WithAuthUser(id = "1", role = "ROLE_TEACHER")
+  @Nested
+  class getAllLessons_메서드는 {
+
+    @Nested
+    class 요청에_해당하는_선생님이_존재하지_않으면 {
+
+      @Test
+      void TeacherNotFoundException_예외가_발생하고_404_응답을_반환한다() throws Exception {
+        when(getAllLessonsQuery.getAllLessons(anyLong())).thenThrow(new TeacherNotFoundException());
+
+        mockMvc.perform(get("/api/teacher/lessons"))
+            .andExpectAll(
+                status().isNotFound(),
+                result -> assertThat(result.getResolvedException()).isInstanceOf(
+                    TeacherNotFoundException.class)
+            );
+      }
+    }
+
+    @Nested
+    class 요청에_해당하는_수업이_존재하지_않으면 {
+
+      @Test
+      void 비어있는_리스트가_담긴_200_응답을_반환한다() throws Exception {
+        when(getAllLessonsQuery.getAllLessons(anyLong())).thenReturn(List.of());
+
+        mockMvc.perform(get("/api/teacher/lessons"))
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.data").isEmpty()
+            );
+      }
+    }
+
+    @Nested
+    class 요청에_해당하는_수업이_존재하면 {
+
+      @Test
+      void GetAllLessonsResponse_리스트가_담긴_200_응답을_반환한다() throws Exception {
+        List<LessonDto> givenLessonDtos = MonkeyUtils.MONKEY.giveMeBuilder(LessonDto.class)
+            .set("id", 1L)
+            .setNotNull("lessonName")
+            .sampleList(5);
+
+        when(getAllLessonsQuery.getAllLessons(anyLong())).thenReturn(givenLessonDtos);
+
+        mockMvc.perform(get("/api/teacher/lessons"))
+            .andExpectAll(
+                status().isOk(),
+                jsonPath("$.data").isNotEmpty()
+            );
+      }
+    }
+  }
+
+}

--- a/src/test/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapterTest.java
+++ b/src/test/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapterTest.java
@@ -5,6 +5,7 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.noti.noti.common.adapter.out.persistance.DaySetConvertor;
 import com.noti.noti.config.QuerydslTestConfig;
 import com.noti.noti.lesson.application.port.out.FrequencyOfLessons;
+import com.noti.noti.lesson.application.port.out.LessonDto;
 import com.noti.noti.lesson.application.port.out.OutCreatedLesson;
 import com.noti.noti.lesson.application.port.out.TodaysLesson;
 import com.noti.noti.lesson.application.port.out.TodaysLessonSearchConditon;
@@ -38,6 +39,33 @@ class LessonPersistenceAdapterTest {
 
   @Autowired
   LessonPersistenceAdapter lessonPersistenceAdapter;
+
+  @Nested
+  class findAllLessonsByTeacherId_메서드는 {
+
+    @Nested
+    class 조건에_해당하는_수업이_존재하지_않으면 {
+
+      @Test
+      void 비어있는_리스트를_반환한다() {
+        List<LessonDto> lessons = lessonPersistenceAdapter.findAllLessonsByTeacherId(1L);
+
+        assertThat(lessons).isEmpty();
+      }
+    }
+
+    @Sql("/data/lesson.sql")
+    @Nested
+    class 조건에_해당하는_수업이_존재하면 {
+
+      @Test
+      void 해당_LessonDto_리스트를_반환한다() {
+        List<LessonDto> lessons = lessonPersistenceAdapter.findAllLessonsByTeacherId(1L);
+
+        assertThat(lessons).isNotEmpty();
+      }
+    }
+  }
 
   @Nested
   class save_메소드는 {
@@ -87,10 +115,11 @@ class LessonPersistenceAdapterTest {
 
     @Nested
     class 수업이_있는_선생님의_ID가_주어지면 {
+
       final TodaysLessonSearchConditon condition = new TodaysLessonSearchConditon(1L);
 
       @Test
-      void 선생님_ID에_해당하는_수업목록_List를_반환한다(){
+      void 선생님_ID에_해당하는_수업목록_List를_반환한다() {
         List<TodaysLesson> todaysLessons = lessonPersistenceAdapter.findTodaysLessons(condition);
 
         assertThat(todaysLessons).isNotEmpty();
@@ -101,6 +130,7 @@ class LessonPersistenceAdapterTest {
 
   @Nested
   class findFrequencyOfLessons_메소드는 {
+
     @Nested
     class 년_월이_주어지고 {
 
@@ -126,7 +156,6 @@ class LessonPersistenceAdapterTest {
           List<FrequencyOfLessons> frequencyOfLessons3 = lessonPersistenceAdapter.findFrequencyOfLessons(
               yearMonth, teacherId3);
 
-
           assertThat(frequencyOfLessons1).size().isEqualTo(2);
           assertThat(frequencyOfLessons2).size().isEqualTo(2);
           assertThat(frequencyOfLessons3).size().isEqualTo(0);
@@ -137,9 +166,11 @@ class LessonPersistenceAdapterTest {
       @Sql("/data/no-homework-lesson.sql")
       @Nested
       class 주어진_월에_숙제가_없다면 {
+
         @Test
         void 비어있는_list를_반환한다() {
-          List<FrequencyOfLessons> frequencyOfLessons = lessonPersistenceAdapter.findFrequencyOfLessons(yearMonth, teacherId1);
+          List<FrequencyOfLessons> frequencyOfLessons = lessonPersistenceAdapter.findFrequencyOfLessons(
+              yearMonth, teacherId1);
 
           assertThat(frequencyOfLessons).isEmpty();
         }

--- a/src/test/java/com/noti/noti/lesson/application/service/AddLessonServiceIntegrationTest.java
+++ b/src/test/java/com/noti/noti/lesson/application/service/AddLessonServiceIntegrationTest.java
@@ -6,9 +6,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 import com.noti.noti.book.exception.BookNotFoundException;
-import com.noti.noti.lesson.adapter.out.persistence.LessonPersistenceAdapter;
 import com.noti.noti.lesson.application.port.in.AddLessonCommand;
 import com.noti.noti.lesson.application.port.in.AddLessonUsecase;
+import com.noti.noti.lesson.application.port.out.FindLessonPort;
 import com.noti.noti.lesson.domain.model.Lesson;
 import com.noti.noti.student.exception.StudentNotFoundException;
 import java.time.LocalTime;
@@ -36,7 +36,7 @@ public class AddLessonServiceIntegrationTest {
   AddLessonUsecase addLessonUsecase;
 
   @Autowired
-  LessonPersistenceAdapter lessonPersistenceAdapter;
+  FindLessonPort findLessonPort;
 
   final String LESSON_NAME = "MATH";
 
@@ -55,7 +55,7 @@ public class AddLessonServiceIntegrationTest {
       assertThatThrownBy(() -> addLessonUsecase.apply(createCommand())).isInstanceOf(
           BookNotFoundException.class);
 
-      Optional<Lesson> lesson = lessonPersistenceAdapter.findById(1L);
+      Optional<Lesson> lesson = findLessonPort.findById(1L);
 
       assertThat(lesson).isNotPresent();
     }
@@ -72,7 +72,7 @@ public class AddLessonServiceIntegrationTest {
       assertThatThrownBy(() -> addLessonUsecase.apply(createCommand())).isInstanceOf(
           StudentNotFoundException.class);
 
-      Optional<Lesson> lessonJpaEntity = lessonPersistenceAdapter.findById(1L);
+      Optional<Lesson> lessonJpaEntity = findLessonPort.findById(1L);
 
       assertThat(lessonJpaEntity).isNotPresent();
     }

--- a/src/test/java/com/noti/noti/lesson/application/service/GetAllLessonsServiceTest.java
+++ b/src/test/java/com/noti/noti/lesson/application/service/GetAllLessonsServiceTest.java
@@ -1,0 +1,94 @@
+package com.noti.noti.lesson.application.service;
+
+import static com.noti.noti.common.MonkeyUtils.TEACHER_FIXTURE;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.noti.noti.common.MonkeyUtils;
+import com.noti.noti.lesson.application.port.out.FindLessonPort;
+import com.noti.noti.lesson.application.port.out.LessonDto;
+import com.noti.noti.teacher.application.exception.TeacherNotFoundException;
+import com.noti.noti.teacher.application.port.out.FindTeacherPort;
+import java.util.List;
+import java.util.Optional;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class GetAllLessonsServiceTest {
+
+  @InjectMocks
+  GetAllLessonsService getAllLessonsService;
+
+  @Mock
+  FindTeacherPort findTeacherPort;
+
+  @Mock
+  FindLessonPort findLessonPort;
+
+  @Nested
+  class getAllLessons_메서드는 {
+
+    @Nested
+    class ID에_해당하는_선생님이_존재하지_않으면 {
+
+      @Test
+      void TeacherNotFoundException_예외가_발생한다() {
+        when(findTeacherPort.findById(anyLong())).thenThrow(new TeacherNotFoundException());
+
+        assertAll(
+            () -> assertThatThrownBy(
+                () -> getAllLessonsService.getAllLessons(anyLong()))
+                .isInstanceOf(TeacherNotFoundException.class),
+            () -> verify(findLessonPort, never()).findAllLessonsByTeacherId(anyLong())
+
+        );
+      }
+    }
+
+    @Nested
+    class 선생님_ID에_해당하는_교재가_존재하지_않으면 {
+
+      @Test
+      void 비어있는_리스트를_반환한다() {
+        when(findTeacherPort.findById(anyLong())).thenReturn(Optional.of(TEACHER_FIXTURE));
+        when(findLessonPort.findAllLessonsByTeacherId(anyLong())).thenReturn(List.of());
+
+        List<LessonDto> allLessons = getAllLessonsService.getAllLessons(anyLong());
+
+        assertThat(allLessons).isEmpty();
+      }
+    }
+
+    @Nested
+    class 선생님_ID에_해당하는_교재가_존재하면 {
+
+      @Test
+      void 해당하는_BookDto_리스트를_반환한다() {
+        List<LessonDto> givenLessonDtos = MonkeyUtils.MONKEY.giveMeBuilder(LessonDto.class)
+            .set("id", 1L)
+            .setNotNull("lessonName")
+            .sampleList(5);
+
+        when(findTeacherPort.findById(anyLong())).thenReturn(Optional.of(TEACHER_FIXTURE));
+        when(findLessonPort.findAllLessonsByTeacherId(anyLong())).thenReturn(givenLessonDtos);
+
+        List<LessonDto> allLessons = getAllLessonsService.getAllLessons(anyLong());
+
+        assertThat(allLessons).hasSize(5);
+      }
+    }
+  }
+}

--- a/src/test/java/com/noti/noti/lesson/application/service/GetTodaysLessonServiceTest.java
+++ b/src/test/java/com/noti/noti/lesson/application/service/GetTodaysLessonServiceTest.java
@@ -13,7 +13,7 @@ import com.noti.noti.homework.application.port.out.TodayHomeworkCondition;
 import com.noti.noti.homework.application.port.out.TodaysHomework;
 import com.noti.noti.homework.application.port.out.TodaysHomework.HomeworkOfStudent;
 import com.noti.noti.lesson.application.port.in.TodaysLessonHomework;
-import com.noti.noti.lesson.application.port.out.FindTodaysLessonPort;
+import com.noti.noti.lesson.application.port.out.FindLessonPort;
 import com.noti.noti.lesson.application.port.out.TodaysLesson;
 import com.noti.noti.lesson.application.port.out.TodaysLesson.LessonOfStudent;
 import com.noti.noti.lesson.application.port.out.TodaysLessonSearchConditon;
@@ -41,7 +41,7 @@ class GetTodaysLessonServiceTest {
   private GetTodaysLessonService getTodaysLessonService;
 
   @Mock
-  private FindTodaysLessonPort findTodaysLessonPort;
+  private FindLessonPort findLessonPort;
 
   @Mock
   private FindTodaysHomeworkPort findTodaysHomeworkPort;
@@ -79,7 +79,7 @@ class GetTodaysLessonServiceTest {
       @Test
       void isLessonCreated_변수가_false인_TodaysLessonHomework_객체를_반환한다() {
         when(findTeacherNicknamePort.findTeacherNickname(TEACHER_ID)).thenReturn(TEACHER_NICKNAME);
-        when(findTodaysLessonPort.findTodaysLessons(
+        when(findLessonPort.findTodaysLessons(
             any(TodaysLessonSearchConditon.class))).thenReturn(
             Collections.emptyList());
 
@@ -109,7 +109,7 @@ class GetTodaysLessonServiceTest {
       @Test
       void isLessonCreated_변수가_true고_수업_목록이_비어있는_TodaysLessonHomework_객체를_반환한다() {
         when(findTeacherNicknamePort.findTeacherNickname(TEACHER_ID)).thenReturn(TEACHER_NICKNAME);
-        when(findTodaysLessonPort.findTodaysLessons(any(TodaysLessonSearchConditon.class)))
+        when(findLessonPort.findTodaysLessons(any(TodaysLessonSearchConditon.class)))
             .thenReturn(createEmptyStudentsTodaysLesson());
 
         TodaysLessonHomework todaysLessonHomework = getTodaysLessonService.getTodaysLessons(
@@ -128,7 +128,7 @@ class GetTodaysLessonServiceTest {
       @Test
       void isLessonCreated_변수가_true고_숙제_목록이_비어있는_TodaysLessonHomework_객체를_반환한다() {
         when(findTeacherNicknamePort.findTeacherNickname(TEACHER_ID)).thenReturn(TEACHER_NICKNAME);
-        when(findTodaysLessonPort.findTodaysLessons(any(TodaysLessonSearchConditon.class)))
+        when(findLessonPort.findTodaysLessons(any(TodaysLessonSearchConditon.class)))
             .thenReturn(createTodaysLesson());
         when(findTodaysHomeworkPort.findTodaysHomeworks(any(TodayHomeworkCondition.class)))
             .thenReturn(Collections.emptyList());
@@ -173,7 +173,7 @@ class GetTodaysLessonServiceTest {
       @Test
       void isLessonCreated_변수가_true고_숙제_수업_학생_목록이_있는_TodaysLessonHomework_객체를_반환한다() {
         when(findTeacherNicknamePort.findTeacherNickname(TEACHER_ID)).thenReturn(TEACHER_NICKNAME);
-        when(findTodaysLessonPort.findTodaysLessons(any(TodaysLessonSearchConditon.class)))
+        when(findLessonPort.findTodaysLessons(any(TodaysLessonSearchConditon.class)))
             .thenReturn(createTodaysLesson());
         when(findTodaysHomeworkPort.findTodaysHomeworks(any(TodayHomeworkCondition.class)))
             .thenReturn(createTodaysHomework());


### PR DESCRIPTION
선생님에 해당하는 모든 수업 조회 기능 구현을 했습니다.
FindLessonPort를 만든 이유는 Find관련 포트를 계속 추가하는 것 보다는 같은 조회 포트에서 메서드를 추가하는 것이 맞다고
생각되어 바꿨습니다. 이전 pr의 교재목록 조회랑 로직이 동일하고 이외에 추가된 부분은 없으니 편하게 봐주시면 됩니다~~~!
