### PR TITLE
Feature/noti 64 [FEAT] 필터 적용시 숙제 목록 조회

### DIFF
--- a/src/main/java/com/noti/noti/error/ErrorCode.java
+++ b/src/main/java/com/noti/noti/error/ErrorCode.java
@@ -44,7 +44,13 @@ public enum ErrorCode {
   Book 관련 예외
    */
   BOOK_NOT_FOUND(404,"B001","해당 책정보가 존재하지 않습니다"),
-  DUPLICATED_TITLE_BOOK(400, "B002", "중복된 교재입니다");
+  DUPLICATED_TITLE_BOOK(400, "B002", "중복된 교재입니다"),
+
+  /*
+  Lesson 관련 예외
+   */
+  LESSON_NOT_FOUND(404, "L001", "해당 수업 정보가 존재하지 않습니다");
+
   private int status;
   private final String code;
   private final String message;

--- a/src/main/java/com/noti/noti/error/ErrorCode.java
+++ b/src/main/java/com/noti/noti/error/ErrorCode.java
@@ -3,7 +3,7 @@ package com.noti.noti.error;
 public enum ErrorCode {
 
   // Common
-  INVALID_INPUT_VALUE(400, "C001", " 올바르지 않은 입력 값입니다"),
+  INVALID_INPUT_VALUE(400, "C001", "올바르지 않은 입력 값입니다"),
   METHOD_NOT_ALLOWED(405, "C002", " 올바르지 않은 호출입니다"),
   ENTITY_NOT_FOUND(400, "C003", " 정보가 존재하지 않습니다"),
   INTERNAL_SERVER_ERROR(500, "C004", "서버 에러"),
@@ -26,6 +26,11 @@ public enum ErrorCode {
   MALFORMED_JWT(401, "J003", "잘못된 토큰입니다"),
   INVALID_SIGNATURE_JWT(401, "J004", "잘못된 토큰입니다"),
   ILLEGAL_ARGUMENT_JWT(401, "J005", "토큰이 비어있거나 잘못되었습니다"),
+
+  /*
+  날짜 관련 error code
+   */
+  INVALID_DATE(400, "D001", "입력한 날짜가 존재하지 않습니다"),
 
   // Student
   STUDENT_NOT_FOUND(404, "S001", "해당 학생 정보가 존재하지 않습니다"),

--- a/src/main/java/com/noti/noti/error/ErrorCode.java
+++ b/src/main/java/com/noti/noti/error/ErrorCode.java
@@ -27,11 +27,6 @@ public enum ErrorCode {
   INVALID_SIGNATURE_JWT(401, "J004", "잘못된 토큰입니다"),
   ILLEGAL_ARGUMENT_JWT(401, "J005", "토큰이 비어있거나 잘못되었습니다"),
 
-  /*
-  날짜 관련 error code
-   */
-  INVALID_DATE(400, "D001", "입력한 날짜가 존재하지 않습니다"),
-
   // Student
   STUDENT_NOT_FOUND(404, "S001", "해당 학생 정보가 존재하지 않습니다"),
 

--- a/src/main/java/com/noti/noti/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/noti/noti/error/GlobalExceptionHandler.java
@@ -10,6 +10,7 @@ import org.springframework.http.converter.HttpMessageNotReadableException;
 import org.springframework.validation.BindException;
 import org.springframework.web.HttpRequestMethodNotSupportedException;
 import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.bind.MissingServletRequestParameterException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.method.annotation.MethodArgumentTypeMismatchException;
@@ -47,12 +48,22 @@ public class GlobalExceptionHandler {
     return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
   }
 
+
   @ExceptionHandler(DateTimeException.class)
-  protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(DateTimeException e) {
+  protected ResponseEntity<ErrorResponse> handleDateTimeException(DateTimeException e) {
+    log.error("Exception : {}, Message : {}", e.getClass(), e.getMessage());
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_DATE);
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(MissingServletRequestParameterException.class)
+  protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
     log.error("Exception : {}, Message : {}", e.getClass(), e.getMessage());
     final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
     return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
   }
+
+
 
   /**
    * enum type 일치하지 않아 binding 못할 경우 발생

--- a/src/main/java/com/noti/noti/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/noti/noti/error/GlobalExceptionHandler.java
@@ -2,6 +2,7 @@ package com.noti.noti.error;
 
 import com.noti.noti.error.exception.BusinessException;
 
+import java.time.DateTimeException;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -42,6 +43,13 @@ public class GlobalExceptionHandler {
   @ExceptionHandler(HttpMessageNotReadableException.class)
   protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(HttpMessageNotReadableException e) {
     log.error("handleHttpMessageNotReadableException", e);
+    final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
+    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
+  }
+
+  @ExceptionHandler(DateTimeException.class)
+  protected ResponseEntity<ErrorResponse> handleHttpMessageNotReadableException(DateTimeException e) {
+    log.error("Exception : {}, Message : {}", e.getClass(), e.getMessage());
     final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_INPUT_VALUE);
     return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
   }

--- a/src/main/java/com/noti/noti/error/GlobalExceptionHandler.java
+++ b/src/main/java/com/noti/noti/error/GlobalExceptionHandler.java
@@ -50,13 +50,6 @@ public class GlobalExceptionHandler {
   }
 
 
-  @ExceptionHandler(DateTimeException.class)
-  protected ResponseEntity<ErrorResponse> handleDateTimeException(DateTimeException e) {
-    log.error("Exception : {}, Message : {}", e.getClass(), e.getMessage());
-    final ErrorResponse response = ErrorResponse.of(ErrorCode.INVALID_DATE);
-    return new ResponseEntity<>(response, HttpStatus.BAD_REQUEST);
-  }
-
   @ExceptionHandler(MissingServletRequestParameterException.class)
   protected ResponseEntity<ErrorResponse> handleMissingServletRequestParameterException(MissingServletRequestParameterException e) {
     log.error("Exception : {}, Message : {}", e.getClass(), e.getMessage());

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/GetHomeworkContentsController.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/GetHomeworkContentsController.java
@@ -1,0 +1,40 @@
+package com.noti.noti.homework.adapter.in.web;
+
+import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
+import com.noti.noti.homework.adapter.in.web.dto.response.HomeworkContentDto;
+import com.noti.noti.homework.application.port.in.GetHomeworkContentQuery;
+import com.noti.noti.homework.application.port.in.HomeworkContentCommand;
+import com.noti.noti.homework.application.port.in.InHomeworkContent;
+import java.time.LocalDate;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.AllArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@AllArgsConstructor
+public class GetHomeworkContentsController {
+
+  private final GetHomeworkContentQuery getHomeworkContentQuery;
+
+
+  @GetMapping("/api/teacher/calendar/filtered/content")
+  public ResponseEntity<SuccessResponse<List<HomeworkContentDto>>> getHomeworkContentInfo(@RequestParam Long lessonId,
+      @RequestParam String date) {
+
+    List<InHomeworkContent> homeworkContents = getHomeworkContentQuery.getHomeworkContents(
+        new HomeworkContentCommand(lessonId, date));
+
+    List<HomeworkContentDto> homeworkContentDtos = new ArrayList<>();
+    homeworkContents.forEach(
+        inHomeworkContent -> homeworkContentDtos.add(new HomeworkContentDto(inHomeworkContent)));
+
+    return ResponseEntity.ok().body(SuccessResponse.create200SuccessResponse(homeworkContentDtos));
+
+  }
+
+
+}

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/GetHomeworkContentsController.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/GetHomeworkContentsController.java
@@ -14,13 +14,16 @@ import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
 import lombok.AllArgsConstructor;
+import org.springframework.format.annotation.DateTimeFormat;
 import org.springframework.http.ResponseEntity;
+import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 
 @RestController
 @AllArgsConstructor
+@Validated
 public class GetHomeworkContentsController {
 
   private final GetHomeworkContentQuery getHomeworkContentQuery;
@@ -41,7 +44,7 @@ public class GetHomeworkContentsController {
       })
   @GetMapping("/api/teacher/calendar/filtered/content")
   public ResponseEntity<SuccessResponse<List<HomeworkContentDto>>> getHomeworkContentInfo(@RequestParam Long lessonId,
-      @RequestParam String date) {
+      @RequestParam @DateTimeFormat(pattern = "yyyy-MM-dd") LocalDate date) {
 
     List<InHomeworkContent> homeworkContents = getHomeworkContentQuery.getHomeworkContents(
         new HomeworkContentCommand(lessonId, date));

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/GetHomeworkContentsController.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/GetHomeworkContentsController.java
@@ -1,10 +1,15 @@
 package com.noti.noti.homework.adapter.in.web;
 
 import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
+import com.noti.noti.error.ErrorResponse;
 import com.noti.noti.homework.adapter.in.web.dto.response.HomeworkContentDto;
 import com.noti.noti.homework.application.port.in.GetHomeworkContentQuery;
 import com.noti.noti.homework.application.port.in.HomeworkContentCommand;
 import com.noti.noti.homework.application.port.in.InHomeworkContent;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import java.time.LocalDate;
 import java.util.ArrayList;
 import java.util.List;
@@ -21,6 +26,19 @@ public class GetHomeworkContentsController {
   private final GetHomeworkContentQuery getHomeworkContentQuery;
 
 
+  @Operation(tags = "필터 적용시 숙제 목록 조회 API", summary = "getHomeworkContentInfo", description = "캘린더에서 분반이 적용된 후 날짜에 해당하는 숙제 목록을 조회한다.",
+      responses = {
+          @ApiResponse(responseCode = "200", description = "성공", useReturnTypeSchema = true),
+          @ApiResponse(responseCode = "500", description = "서버에러", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))}),
+          @ApiResponse(responseCode = "401", description = "안증되지 않은 유저입니다", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))}),
+          @ApiResponse(responseCode = "400", description = "올바르지 않은 값입니다.", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))})
+      })
   @GetMapping("/api/teacher/calendar/filtered/content")
   public ResponseEntity<SuccessResponse<List<HomeworkContentDto>>> getHomeworkContentInfo(@RequestParam Long lessonId,
       @RequestParam String date) {

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/dto/response/HomeworkContentDto.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/dto/response/HomeworkContentDto.java
@@ -1,0 +1,18 @@
+package com.noti.noti.homework.adapter.in.web.dto.response;
+
+import com.noti.noti.homework.application.port.in.InHomeworkContent;
+import lombok.Getter;
+
+@Getter
+public class HomeworkContentDto {
+
+  private String homeworkName;
+  private int studentCnt;
+  private int completeCnt;
+
+  public HomeworkContentDto(InHomeworkContent in) {
+    this.homeworkName = in.getHomeworkName();
+    this.studentCnt = in.getStudentCnt();
+    this.completeCnt = in.getCompleteCnt();
+  }
+}

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/dto/response/HomeworkContentDto.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/dto/response/HomeworkContentDto.java
@@ -1,13 +1,17 @@
 package com.noti.noti.homework.adapter.in.web.dto.response;
 
 import com.noti.noti.homework.application.port.in.InHomeworkContent;
+import io.swagger.v3.oas.annotations.media.Schema;
 import lombok.Getter;
 
 @Getter
 public class HomeworkContentDto {
 
+  @Schema(description = "숙제명", example = "단어 10개 외우기")
   private String homeworkName;
+  @Schema(description = "숙제를 받은 학생 수", example = "21")
   private int studentCnt;
+  @Schema(description = "숙제를 완료한 학생 수", example = "3")
   private int completeCnt;
 
   public HomeworkContentDto(InHomeworkContent in) {

--- a/src/main/java/com/noti/noti/homework/adapter/out/persistence/HomeworkPersistenceAdapter.java
+++ b/src/main/java/com/noti/noti/homework/adapter/out/persistence/HomeworkPersistenceAdapter.java
@@ -2,8 +2,10 @@ package com.noti.noti.homework.adapter.out.persistence;
 
 import com.noti.noti.homework.adapter.out.persistence.jpa.HomeworkJpaRepository;
 import com.noti.noti.homework.application.port.out.FindFilteredHomeworkPort;
+import com.noti.noti.homework.application.port.out.FindHomeworkContentPort;
 import com.noti.noti.homework.application.port.out.FindTodaysHomeworkPort;
 import com.noti.noti.homework.application.port.out.OutFilteredHomeworkFrequency;
+import com.noti.noti.homework.application.port.out.OutHomeworkContent;
 import com.noti.noti.homework.application.port.out.TodayHomeworkCondition;
 import com.noti.noti.homework.application.port.out.TodaysHomework;
 import java.time.LocalDateTime;
@@ -14,11 +16,12 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 public class HomeworkPersistenceAdapter implements FindTodaysHomeworkPort,
-    FindFilteredHomeworkPort {
+    FindFilteredHomeworkPort, FindHomeworkContentPort {
 
   private final HomeworkMapper homeworkMapper;
   private final HomeworkJpaRepository homeworkJpaRepository;
   private final HomeworkQueryRepository homeworkQueryRepository;
+
 
   @Override
   public List<TodaysHomework> findTodaysHomeworks(TodayHomeworkCondition condition) {
@@ -32,4 +35,9 @@ public class HomeworkPersistenceAdapter implements FindTodaysHomeworkPort,
         teacherId, lessonId, startOfMonth, startOfMonth.plusMonths(1).minusSeconds(1));
   }
 
+  @Override
+  public List<OutHomeworkContent> findHomeworkContents(Long lessonId, LocalDateTime startOfMonth) {
+
+    return homeworkQueryRepository.findHomeworkContents(lessonId, startOfMonth);
+  }
 }

--- a/src/main/java/com/noti/noti/homework/adapter/out/persistence/HomeworkQueryRepository.java
+++ b/src/main/java/com/noti/noti/homework/adapter/out/persistence/HomeworkQueryRepository.java
@@ -90,14 +90,14 @@ public class HomeworkQueryRepository {
         .innerJoin(homeworkJpaEntity.lessonJpaEntity, lessonJpaEntity)
         .where(
             eqTeacherId(teacherId),
-            eqLessonId(lessonId),
+            eqLessonIdOfTeacher(lessonId),
             betweenYearMonth(startDateOfMonth, endDateOfMonth)
         )
         .groupBy(lessonJpaEntity.startTime)
         .fetch();
   }
 
-  private BooleanExpression eqLessonId(Long lessonId) {
+  private BooleanExpression eqLessonIdOfTeacher(Long lessonId) {
     log.info("lesson Id: {} ", lessonId);
     return lessonId != null ? lessonJpaEntity.teacherJpaEntity.id.eq(lessonId) : null;
   }
@@ -121,14 +121,19 @@ public class HomeworkQueryRepository {
         .from(studentHomeworkJpaEntity)
         .join(studentHomeworkJpaEntity.homeworkJpaEntity, homeworkJpaEntity)
         .where(
-            eqLessonId(lessonId),
+            eqLessonOfHomework(lessonId),
             eqYearAndMonthOfStartTime(date)
         )
+        .groupBy(homeworkJpaEntity)
         .fetch();
   }
 
   private BooleanExpression eqYearAndMonthOfStartTime(LocalDateTime date) {
     return date != null ? homeworkJpaEntity.startTime.between(date, date.plusDays(1).minusSeconds(1)) : null;
+  }
+
+  private BooleanExpression eqLessonOfHomework(Long lessonId) {
+    return lessonId != null ? homeworkJpaEntity.lessonJpaEntity.id.eq(lessonId) : null;
   }
 
 }

--- a/src/main/java/com/noti/noti/homework/adapter/out/persistence/HomeworkQueryRepository.java
+++ b/src/main/java/com/noti/noti/homework/adapter/out/persistence/HomeworkQueryRepository.java
@@ -7,6 +7,7 @@ import static com.querydsl.core.group.GroupBy.groupBy;
 import static com.querydsl.core.group.GroupBy.list;
 
 import com.noti.noti.homework.application.port.out.OutFilteredHomeworkFrequency;
+import com.noti.noti.homework.application.port.out.OutHomeworkContent;
 import com.noti.noti.homework.application.port.out.TodayHomeworkCondition;
 import com.noti.noti.homework.application.port.out.TodaysHomework;
 import com.querydsl.core.types.Ops;
@@ -110,9 +111,24 @@ public class HomeworkQueryRepository {
     }
   }
 
+  public List<OutHomeworkContent> findHomeworkContents(Long lessonId, LocalDateTime date) {
+    return queryFactory
+        .select(Projections.constructor(OutHomeworkContent.class,
+            homeworkJpaEntity.homeworkName,
+            studentHomeworkJpaEntity.studentJpaEntity.id.count().as("studentCnt"),
+            studentHomeworkJpaEntity.homeworkStatus.when(true).then(1L).otherwise(0L)
+                .sum().as("completeCnt")))
+        .from(studentHomeworkJpaEntity)
+        .join(studentHomeworkJpaEntity.homeworkJpaEntity, homeworkJpaEntity)
+        .where(
+            eqLessonId(lessonId),
+            eqYearAndMonthOfStartTime(date)
+        )
+        .fetch();
+  }
 
-
-
-
+  private BooleanExpression eqYearAndMonthOfStartTime(LocalDateTime date) {
+    return date != null ? homeworkJpaEntity.startTime.between(date, date.plusDays(1).minusSeconds(1)) : null;
+  }
 
 }

--- a/src/main/java/com/noti/noti/homework/application/port/in/GetHomeworkContentQuery.java
+++ b/src/main/java/com/noti/noti/homework/application/port/in/GetHomeworkContentQuery.java
@@ -1,0 +1,14 @@
+package com.noti.noti.homework.application.port.in;
+
+import java.util.List;
+
+public interface GetHomeworkContentQuery {
+
+  /**
+   * 전달한 날짜와 분반에 해당하는 숙제 목록을 조회한다.
+   * @param command 날짜, 수업 id 전달
+   * @return 날짜와 분반에 해당하는 숙제 목록 반환
+   */
+  List<InHomeworkContent> getHomeworkContents(HomeworkContentCommand command);
+
+}

--- a/src/main/java/com/noti/noti/homework/application/port/in/HomeworkContentCommand.java
+++ b/src/main/java/com/noti/noti/homework/application/port/in/HomeworkContentCommand.java
@@ -1,14 +1,13 @@
 package com.noti.noti.homework.application.port.in;
 
-import java.time.DateTimeException;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import lombok.Getter;
-import lombok.extern.slf4j.Slf4j;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Slf4j
+@NoArgsConstructor
 public class HomeworkContentCommand {
 
   private Long lessonId;

--- a/src/main/java/com/noti/noti/homework/application/port/in/HomeworkContentCommand.java
+++ b/src/main/java/com/noti/noti/homework/application/port/in/HomeworkContentCommand.java
@@ -13,8 +13,8 @@ public class HomeworkContentCommand {
   private Long lessonId;
   private LocalDateTime date;
 
-  public HomeworkContentCommand(Long lessonId, String date) {
+  public HomeworkContentCommand(Long lessonId, LocalDate date) {
     this.lessonId = lessonId;
-    this.date = LocalDate.parse(date, DateTimeFormatter.ISO_DATE).atStartOfDay();
+    this.date = date.atStartOfDay();
   }
 }

--- a/src/main/java/com/noti/noti/homework/application/port/in/HomeworkContentCommand.java
+++ b/src/main/java/com/noti/noti/homework/application/port/in/HomeworkContentCommand.java
@@ -1,0 +1,21 @@
+package com.noti.noti.homework.application.port.in;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import java.time.format.DateTimeFormatter;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+
+@Getter
+@Slf4j
+public class HomeworkContentCommand {
+
+  private Long lessonId;
+  private LocalDateTime date;
+
+  public HomeworkContentCommand(Long lessonId, String date) {
+    this.lessonId = lessonId;
+    this.date = LocalDate.parse(date, DateTimeFormatter.ISO_DATE).atStartOfDay();
+  }
+}

--- a/src/main/java/com/noti/noti/homework/application/port/in/InHomeworkContent.java
+++ b/src/main/java/com/noti/noti/homework/application/port/in/InHomeworkContent.java
@@ -3,10 +3,10 @@ package com.noti.noti.homework.application.port.in;
 
 import com.noti.noti.homework.application.port.out.OutHomeworkContent;
 import lombok.Getter;
-import lombok.Setter;
+import lombok.NoArgsConstructor;
 
 @Getter
-@Setter
+@NoArgsConstructor
 public class InHomeworkContent {
 
 

--- a/src/main/java/com/noti/noti/homework/application/port/in/InHomeworkContent.java
+++ b/src/main/java/com/noti/noti/homework/application/port/in/InHomeworkContent.java
@@ -1,0 +1,23 @@
+package com.noti.noti.homework.application.port.in;
+
+
+import com.noti.noti.homework.application.port.out.OutHomeworkContent;
+import lombok.Getter;
+import lombok.Setter;
+
+@Getter
+@Setter
+public class InHomeworkContent {
+
+
+  private String homeworkName;
+  private int studentCnt;
+  private int completeCnt;
+
+
+  public InHomeworkContent(OutHomeworkContent out) {
+    this.homeworkName = out.getHomeworkName();
+    this.studentCnt = out.getStudentCnt();
+    this.completeCnt = out.getCompleteCnt();
+  }
+}

--- a/src/main/java/com/noti/noti/homework/application/port/out/FindHomeworkContentPort.java
+++ b/src/main/java/com/noti/noti/homework/application/port/out/FindHomeworkContentPort.java
@@ -1,0 +1,10 @@
+package com.noti.noti.homework.application.port.out;
+
+import java.time.LocalDateTime;
+import java.util.List;
+
+public interface FindHomeworkContentPort {
+
+  List<OutHomeworkContent> findHomeworkContents(Long lessonId, LocalDateTime date);
+
+}

--- a/src/main/java/com/noti/noti/homework/application/port/out/OutHomeworkContent.java
+++ b/src/main/java/com/noti/noti/homework/application/port/out/OutHomeworkContent.java
@@ -11,9 +11,9 @@ public class OutHomeworkContent {
   private int studentCnt;
   private int completeCnt;
 
-  public OutHomeworkContent(String homeworkName, int studentCnt, int completeCnt) {
+  public OutHomeworkContent(String homeworkName, Long studentCnt, Long completeCnt) {
     this.homeworkName = homeworkName;
-    this.studentCnt = studentCnt;
-    this.completeCnt = completeCnt;
+    this.studentCnt = studentCnt.intValue();
+    this.completeCnt = completeCnt.intValue();
   }
 }

--- a/src/main/java/com/noti/noti/homework/application/port/out/OutHomeworkContent.java
+++ b/src/main/java/com/noti/noti/homework/application/port/out/OutHomeworkContent.java
@@ -1,8 +1,10 @@
 package com.noti.noti.homework.application.port.out;
 
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class OutHomeworkContent {
 
   private String homeworkName;

--- a/src/main/java/com/noti/noti/homework/application/port/out/OutHomeworkContent.java
+++ b/src/main/java/com/noti/noti/homework/application/port/out/OutHomeworkContent.java
@@ -1,0 +1,17 @@
+package com.noti.noti.homework.application.port.out;
+
+import lombok.Getter;
+
+@Getter
+public class OutHomeworkContent {
+
+  private String homeworkName;
+  private int studentCnt;
+  private int completeCnt;
+
+  public OutHomeworkContent(String homeworkName, int studentCnt, int completeCnt) {
+    this.homeworkName = homeworkName;
+    this.studentCnt = studentCnt;
+    this.completeCnt = completeCnt;
+  }
+}

--- a/src/main/java/com/noti/noti/homework/application/service/GetFilteredHomeworkService.java
+++ b/src/main/java/com/noti/noti/homework/application/service/GetFilteredHomeworkService.java
@@ -10,6 +10,8 @@ import com.noti.noti.homework.application.port.out.FindFilteredHomeworkPort;
 import com.noti.noti.homework.application.port.out.FindHomeworkContentPort;
 import com.noti.noti.homework.application.port.out.OutFilteredHomeworkFrequency;
 import com.noti.noti.homework.application.port.out.OutHomeworkContent;
+import com.noti.noti.lesson.application.port.out.CheckLessonExistencePort;
+import com.noti.noti.lesson.exception.LessonNotFoundException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -23,6 +25,7 @@ public class GetFilteredHomeworkService implements GetFilteredHomeworkQuery,
 
   private final FindFilteredHomeworkPort findFilteredHomeworkPort;
   private final FindHomeworkContentPort findHomeworkContentPort;
+  private final CheckLessonExistencePort checkLessonExistencePort;
 
   @Override
   public List<InFilteredHomeworkFrequency> getFilteredHomeworks(FilteredHomeworkCommand command) {
@@ -35,6 +38,9 @@ public class GetFilteredHomeworkService implements GetFilteredHomeworkQuery,
 
   @Override
   public List<InHomeworkContent> getHomeworkContents(HomeworkContentCommand command) {
+
+    if (!checkLessonExistencePort.existsById(command.getLessonId()))
+      throw new LessonNotFoundException(command.getLessonId());
 
     List<OutHomeworkContent> homeworkContents = findHomeworkContentPort.findHomeworkContents(
         command.getLessonId(), command.getDate());

--- a/src/main/java/com/noti/noti/homework/application/service/GetFilteredHomeworkService.java
+++ b/src/main/java/com/noti/noti/homework/application/service/GetFilteredHomeworkService.java
@@ -2,9 +2,15 @@ package com.noti.noti.homework.application.service;
 
 import com.noti.noti.homework.application.port.in.FilteredHomeworkCommand;
 import com.noti.noti.homework.application.port.in.GetFilteredHomeworkQuery;
+import com.noti.noti.homework.application.port.in.GetHomeworkContentQuery;
+import com.noti.noti.homework.application.port.in.HomeworkContentCommand;
 import com.noti.noti.homework.application.port.in.InFilteredHomeworkFrequency;
+import com.noti.noti.homework.application.port.in.InHomeworkContent;
 import com.noti.noti.homework.application.port.out.FindFilteredHomeworkPort;
+import com.noti.noti.homework.application.port.out.FindHomeworkContentPort;
 import com.noti.noti.homework.application.port.out.OutFilteredHomeworkFrequency;
+import com.noti.noti.homework.application.port.out.OutHomeworkContent;
+import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -12,9 +18,11 @@ import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
-public class GetFilteredHomeworkService implements GetFilteredHomeworkQuery {
+public class GetFilteredHomeworkService implements GetFilteredHomeworkQuery,
+    GetHomeworkContentQuery {
 
   private final FindFilteredHomeworkPort findFilteredHomeworkPort;
+  private final FindHomeworkContentPort findHomeworkContentPort;
 
   @Override
   public List<InFilteredHomeworkFrequency> getFilteredHomeworks(FilteredHomeworkCommand command) {
@@ -23,6 +31,17 @@ public class GetFilteredHomeworkService implements GetFilteredHomeworkQuery {
     return outFilteredHomeworks.stream()
         .map(InFilteredHomeworkFrequency::new)
         .collect(Collectors.toList());
+  }
+
+  @Override
+  public List<InHomeworkContent> getHomeworkContents(HomeworkContentCommand command) {
+
+    List<OutHomeworkContent> homeworkContents = findHomeworkContentPort.findHomeworkContents(
+        command.getLessonId(), command.getDate());
+    List<InHomeworkContent> in = new ArrayList<>();
+    homeworkContents.forEach(out -> in.add(new InHomeworkContent(out)));
+
+    return in;
   }
 }
 

--- a/src/main/java/com/noti/noti/homework/application/service/GetFilteredHomeworkService.java
+++ b/src/main/java/com/noti/noti/homework/application/service/GetFilteredHomeworkService.java
@@ -2,17 +2,9 @@ package com.noti.noti.homework.application.service;
 
 import com.noti.noti.homework.application.port.in.FilteredHomeworkCommand;
 import com.noti.noti.homework.application.port.in.GetFilteredHomeworkQuery;
-import com.noti.noti.homework.application.port.in.GetHomeworkContentQuery;
-import com.noti.noti.homework.application.port.in.HomeworkContentCommand;
 import com.noti.noti.homework.application.port.in.InFilteredHomeworkFrequency;
-import com.noti.noti.homework.application.port.in.InHomeworkContent;
 import com.noti.noti.homework.application.port.out.FindFilteredHomeworkPort;
-import com.noti.noti.homework.application.port.out.FindHomeworkContentPort;
 import com.noti.noti.homework.application.port.out.OutFilteredHomeworkFrequency;
-import com.noti.noti.homework.application.port.out.OutHomeworkContent;
-import com.noti.noti.lesson.application.port.out.CheckLessonExistencePort;
-import com.noti.noti.lesson.exception.LessonNotFoundException;
-import java.util.ArrayList;
 import java.util.List;
 import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
@@ -20,12 +12,9 @@ import org.springframework.stereotype.Service;
 
 @RequiredArgsConstructor
 @Service
-public class GetFilteredHomeworkService implements GetFilteredHomeworkQuery,
-    GetHomeworkContentQuery {
+public class GetFilteredHomeworkService implements GetFilteredHomeworkQuery {
 
   private final FindFilteredHomeworkPort findFilteredHomeworkPort;
-  private final FindHomeworkContentPort findHomeworkContentPort;
-  private final CheckLessonExistencePort checkLessonExistencePort;
 
   @Override
   public List<InFilteredHomeworkFrequency> getFilteredHomeworks(FilteredHomeworkCommand command) {
@@ -36,18 +25,6 @@ public class GetFilteredHomeworkService implements GetFilteredHomeworkQuery,
         .collect(Collectors.toList());
   }
 
-  @Override
-  public List<InHomeworkContent> getHomeworkContents(HomeworkContentCommand command) {
 
-    if (!checkLessonExistencePort.existsById(command.getLessonId()))
-      throw new LessonNotFoundException(command.getLessonId());
-
-    List<OutHomeworkContent> homeworkContents = findHomeworkContentPort.findHomeworkContents(
-        command.getLessonId(), command.getDate());
-    List<InHomeworkContent> in = new ArrayList<>();
-    homeworkContents.forEach(out -> in.add(new InHomeworkContent(out)));
-
-    return in;
-  }
 }
 

--- a/src/main/java/com/noti/noti/homework/application/service/GetHomeworkContentService.java
+++ b/src/main/java/com/noti/noti/homework/application/service/GetHomeworkContentService.java
@@ -1,0 +1,35 @@
+package com.noti.noti.homework.application.service;
+
+import com.noti.noti.homework.application.port.in.GetHomeworkContentQuery;
+import com.noti.noti.homework.application.port.in.HomeworkContentCommand;
+import com.noti.noti.homework.application.port.in.InHomeworkContent;
+import com.noti.noti.homework.application.port.out.FindHomeworkContentPort;
+import com.noti.noti.homework.application.port.out.OutHomeworkContent;
+import com.noti.noti.lesson.application.port.out.CheckLessonExistencePort;
+import com.noti.noti.lesson.exception.LessonNotFoundException;
+import java.util.ArrayList;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+@RequiredArgsConstructor
+@Service
+public class GetHomeworkContentService implements GetHomeworkContentQuery {
+
+  private final FindHomeworkContentPort findHomeworkContentPort;
+  private final CheckLessonExistencePort checkLessonExistencePort;
+
+  @Override
+  public List<InHomeworkContent> getHomeworkContents(HomeworkContentCommand command) {
+
+    if (!checkLessonExistencePort.existsById(command.getLessonId()))
+      throw new LessonNotFoundException(command.getLessonId());
+
+    List<OutHomeworkContent> homeworkContents = findHomeworkContentPort.findHomeworkContents(
+        command.getLessonId(), command.getDate());
+    List<InHomeworkContent> in = new ArrayList<>();
+    homeworkContents.forEach(out -> in.add(new InHomeworkContent(out)));
+
+    return in;
+  }
+}

--- a/src/main/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapter.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapter.java
@@ -2,12 +2,13 @@ package com.noti.noti.lesson.adapter.out.persistence;
 
 import com.noti.noti.lesson.adapter.out.persistence.jpa.LessonJpaRepository;
 import com.noti.noti.lesson.adapter.out.persistence.jpa.model.LessonJpaEntity;
-import com.noti.noti.lesson.application.port.out.OutCreatedLesson;
+import com.noti.noti.lesson.application.port.out.CheckLessonExistencePort;
 import com.noti.noti.lesson.application.port.out.FindCreatedLessonsPort;
 import com.noti.noti.lesson.application.port.out.FindLessonPort;
 import com.noti.noti.lesson.application.port.out.FrequencyOfLessons;
 import com.noti.noti.lesson.application.port.out.FrequencyOfLessonsPort;
 import com.noti.noti.lesson.application.port.out.LessonDto;
+import com.noti.noti.lesson.application.port.out.OutCreatedLesson;
 import com.noti.noti.lesson.application.port.out.SaveLessonPort;
 import com.noti.noti.lesson.application.port.out.TodaysLesson;
 import com.noti.noti.lesson.application.port.out.TodaysLessonSearchConditon;
@@ -22,7 +23,7 @@ import org.springframework.stereotype.Component;
 @Component
 @RequiredArgsConstructor
 class LessonPersistenceAdapter implements SaveLessonPort, FindLessonPort,
-    FrequencyOfLessonsPort, FindCreatedLessonsPort {
+    FrequencyOfLessonsPort, FindCreatedLessonsPort, CheckLessonExistencePort {
 
   private final LessonJpaRepository lessonJpaRepository;
   private final LessonMapper lessonMapper;
@@ -55,6 +56,11 @@ class LessonPersistenceAdapter implements SaveLessonPort, FindLessonPort,
 
   public Optional<Lesson> findById(Long id) {
     return lessonJpaRepository.findById(id).map(lessonMapper::mapToDomainEntity);
+  }
+
+  @Override
+  public boolean existsById(Long lessonId) {
+    return lessonJpaRepository.existsById(lessonId);
   }
 
   /**

--- a/src/main/java/com/noti/noti/lesson/adapter/out/persistence/jpa/LessonJpaRepository.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/out/persistence/jpa/LessonJpaRepository.java
@@ -5,4 +5,6 @@ import org.springframework.data.jpa.repository.JpaRepository;
 
 public interface LessonJpaRepository extends JpaRepository<LessonJpaEntity, Long> {
 
+  @Override
+  boolean existsById(Long lessonId);
 }

--- a/src/main/java/com/noti/noti/lesson/application/port/out/CheckLessonExistencePort.java
+++ b/src/main/java/com/noti/noti/lesson/application/port/out/CheckLessonExistencePort.java
@@ -1,0 +1,13 @@
+package com.noti.noti.lesson.application.port.out;
+
+public interface CheckLessonExistencePort {
+
+  /**
+   * 수업의 존재를 확인한다
+   * @param lessonId 수업 id
+   * @return 해당하는 id를 가진 수업의 존재여부
+   */
+  boolean existsById(Long lessonId);
+
+
+}

--- a/src/main/java/com/noti/noti/lesson/exception/LessonNotFoundException.java
+++ b/src/main/java/com/noti/noti/lesson/exception/LessonNotFoundException.java
@@ -1,0 +1,11 @@
+package com.noti.noti.lesson.exception;
+
+import com.noti.noti.error.ErrorCode;
+import com.noti.noti.error.exception.BusinessException;
+
+public class LessonNotFoundException extends BusinessException {
+
+  public LessonNotFoundException(Long id) {
+    super("수업 ID : " + id, ErrorCode.LESSON_NOT_FOUND);
+  }
+}

--- a/src/test/java/com/noti/noti/homework/adapter/in/web/GetHomeworkContentsControllerTest.java
+++ b/src/test/java/com/noti/noti/homework/adapter/in/web/GetHomeworkContentsControllerTest.java
@@ -117,8 +117,29 @@ class GetHomeworkContentsControllerTest {
                     .params(createInfo(integers().greaterOrEqual(1).sample().toString(), "2023-02-30")))
             .andExpect(status().is(400))
             .andExpect(jsonPath("$.status").value(400))
-            .andExpect(jsonPath("$.message").value("입력한 날짜가 존재하지 않습니다"))
-            .andExpect(jsonPath("$.code").value("D001"));
+            .andExpect(jsonPath("$.message").value("올바르지 않은 입력 값입니다"))
+            .andExpect(jsonPath("$.code").value("C001"));
+      }
+
+      @Test
+      @WithAuthUser(id = "1", role = "TEACHER")
+      public void 날짜_형식이_다를_때_응답코드_400() throws Exception {
+        //given
+        List<InHomeworkContent> inHomeworkContents = createListRandomSizeBetween(1, 10);
+
+        //when
+        Mockito.when(
+                getHomeworkContentQuery.getHomeworkContents(Mockito.any(HomeworkContentCommand.class)))
+            .thenReturn(inHomeworkContents);
+
+        //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/teacher/calendar/filtered/content")
+                    .params(createInfo(integers().greaterOrEqual(1).sample().toString(), "2023:02:10")))
+            .andExpect(status().is(400))
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.message").value("올바르지 않은 입력 값입니다"))
+            .andExpect(jsonPath("$.code").value("C001"));
       }
 
       @Test

--- a/src/test/java/com/noti/noti/homework/adapter/in/web/GetHomeworkContentsControllerTest.java
+++ b/src/test/java/com/noti/noti/homework/adapter/in/web/GetHomeworkContentsControllerTest.java
@@ -11,6 +11,7 @@ import com.noti.noti.config.security.jwt.filter.CustomJwtFilter;
 import com.noti.noti.homework.application.port.in.GetHomeworkContentQuery;
 import com.noti.noti.homework.application.port.in.HomeworkContentCommand;
 import com.noti.noti.homework.application.port.in.InHomeworkContent;
+import com.noti.noti.lesson.exception.LessonNotFoundException;
 import java.time.LocalDate;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
@@ -118,6 +119,25 @@ class GetHomeworkContentsControllerTest {
             .andExpect(jsonPath("$.status").value(400))
             .andExpect(jsonPath("$.message").value("입력한 날짜가 존재하지 않습니다"))
             .andExpect(jsonPath("$.code").value("D001"));
+      }
+
+      @Test
+      @WithAuthUser(id = "1", role = "TEACHER")
+      public void 존재하지_않는_수업일_때_응답코드_404() throws Exception {
+        //given
+        Mockito.when(
+                getHomeworkContentQuery.getHomeworkContents(Mockito.any(HomeworkContentCommand.class)))
+            .thenThrow(new LessonNotFoundException(MONKEY.giveMeOne(Long.class)));
+
+        //when
+        //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/teacher/calendar/filtered/content")
+                    .params(createInfo(integers().greaterOrEqual(1).sample().toString(), "2023-02-22")))
+            .andExpect(status().is(404))
+            .andExpect(jsonPath("$.status").value(404))
+            .andExpect(jsonPath("$.message").value("해당 수업 정보가 존재하지 않습니다"))
+            .andExpect(jsonPath("$.code").value("L001"));
       }
 
       @Test

--- a/src/test/java/com/noti/noti/homework/adapter/in/web/GetHomeworkContentsControllerTest.java
+++ b/src/test/java/com/noti/noti/homework/adapter/in/web/GetHomeworkContentsControllerTest.java
@@ -1,0 +1,206 @@
+package com.noti.noti.homework.adapter.in.web;
+
+import static com.noti.noti.common.MonkeyUtils.MONKEY;
+import static net.jqwik.api.Arbitraries.integers;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.noti.noti.common.WithAuthUser;
+import com.noti.noti.config.JacksonConfiguration;
+import com.noti.noti.config.security.jwt.filter.CustomJwtFilter;
+import com.noti.noti.homework.application.port.in.GetHomeworkContentQuery;
+import com.noti.noti.homework.application.port.in.HomeworkContentCommand;
+import com.noti.noti.homework.application.port.in.InHomeworkContent;
+import java.time.LocalDate;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.request.MockMvcRequestBuilders;
+import org.springframework.util.LinkedMultiValueMap;
+import org.springframework.util.MultiValueMap;
+
+@DisplayName("GetHomeworkContentsControllerTest 클래스")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Import(JacksonConfiguration.class)
+@WebMvcTest(controllers = GetHomeworkContentsController.class,
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE, classes = CustomJwtFilter.class))
+class GetHomeworkContentsControllerTest {
+
+  @Autowired
+  private MockMvc mockMvc;
+
+  @MockBean
+  private GetHomeworkContentQuery getHomeworkContentQuery;
+
+
+  @Nested
+  class getHomeworkContentInfo_메서드는 {
+
+    @Nested
+    class 파라미터_조건이_유효하면_응답코드_200 {
+
+      @Test
+      @WithAuthUser(id = "1", role = "TEACHER")
+      public void 해당_수업이_있으면_숙제목록_리스트_반환() throws Exception {
+        //given
+        List<InHomeworkContent> inHomeworkContents = createListRandomSizeBetween(1, 10);
+
+        //when
+        Mockito.when(getHomeworkContentQuery.getHomeworkContents(Mockito.any(HomeworkContentCommand.class)))
+            .thenReturn(inHomeworkContents);
+
+        //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/teacher/calendar/filtered/content")
+                    .params(createInfo(integers().greaterOrEqual(1).sample().toString(), MONKEY.giveMeOne(LocalDate.class).toString())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.message").value("성공"))
+            .andExpect(jsonPath("$.data.size()").value(inHomeworkContents.size()));
+
+      }
+
+      @Test
+      @WithAuthUser(id = "1", role = "TEACHER")
+      public void 해당_수업이_없다면_빈_리스트_반환() throws Exception {
+        // given
+        List<InHomeworkContent> inHomeworkContents = createListRandomSizeBetween(0, 0);
+
+        //when
+        Mockito.when(
+                getHomeworkContentQuery.getHomeworkContents(Mockito.any(HomeworkContentCommand.class)))
+            .thenReturn(inHomeworkContents);
+
+        //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/teacher/calendar/filtered/content")
+                    .params(createInfo(integers().greaterOrEqual(1).sample().toString(), MONKEY.giveMeOne(LocalDate.class).toString())))
+            .andExpect(status().isOk())
+            .andExpect(jsonPath("$.status").value(200))
+            .andExpect(jsonPath("$.message").value("성공"))
+            .andExpect(jsonPath("$.data.size()").value(0));
+      }
+
+    }
+
+
+    @Nested
+    class 파라미터_조건이_유효하지_않을_때_응답코드_4XX {
+
+      @Test
+      @WithAuthUser(id = "1", role = "TEACHER")
+      public void 존재하지_않는_날짜일_때_응답코드_400() throws Exception {
+        //given
+        List<InHomeworkContent> inHomeworkContents = createListRandomSizeBetween(1, 10);
+
+        //when
+        Mockito.when(
+                getHomeworkContentQuery.getHomeworkContents(Mockito.any(HomeworkContentCommand.class)))
+            .thenReturn(inHomeworkContents);
+
+        //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/teacher/calendar/filtered/content")
+                    .params(createInfo(integers().greaterOrEqual(1).sample().toString(), "2023-02-30")))
+            .andExpect(status().is(400))
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.message").value("입력한 날짜가 존재하지 않습니다"))
+            .andExpect(jsonPath("$.code").value("D001"));
+      }
+
+      @Test
+      @WithAuthUser(id = "1", role = "TEACHER")
+      public void 날짜값이_null일_때_응답코드_400() throws Exception {
+        //given
+        List<InHomeworkContent> inHomeworkContents = createListRandomSizeBetween(1, 10);
+
+        //when
+        Mockito.when(
+                getHomeworkContentQuery.getHomeworkContents(Mockito.any(HomeworkContentCommand.class)))
+            .thenReturn(inHomeworkContents);
+
+        //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/teacher/calendar/filtered/content")
+                    .params(createInfo(integers().greaterOrEqual(1).sample().toString(), null)))
+            .andExpect(status().is(400))
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.message").value("올바르지 않은 입력 값입니다"))
+            .andExpect(jsonPath("$.code").value("C001"));
+
+      }
+
+      @Test
+      @WithAuthUser(id = "1", role = "TEACHER")
+      public void 수업id가_null일_때_응답코드_4001() throws Exception {
+        //given
+        List<InHomeworkContent> inHomeworkContents = createListRandomSizeBetween(1, 10);
+
+        //when
+        Mockito.when(
+                getHomeworkContentQuery.getHomeworkContents(Mockito.any(HomeworkContentCommand.class)))
+            .thenReturn(inHomeworkContents);
+
+        //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/teacher/calendar/filtered/content")
+                    .params(createInfo(null, MONKEY.giveMeOne(LocalDate.class).toString())))
+            .andExpect(status().is(400))
+            .andExpect(jsonPath("$.status").value(400))
+            .andExpect(jsonPath("$.message").value("올바르지 않은 입력 값입니다"))
+            .andExpect(jsonPath("$.code").value("C001"));
+      }
+
+      @Test
+      public void 선생님_id가_존재하지_않을_때_응답코드_401() throws Exception {
+        //given
+        List<InHomeworkContent> inHomeworkContents = createListRandomSizeBetween(1, 10);
+
+        //when
+        Mockito.when(
+                getHomeworkContentQuery.getHomeworkContents(Mockito.any(HomeworkContentCommand.class)))
+            .thenReturn(inHomeworkContents);
+
+        //TODO: body ㄴ
+        //then
+        mockMvc.perform(
+                MockMvcRequestBuilders.get("/api/teacher/calendar/filtered/content")
+                    .params(createInfo("1", "2022-03-09")))
+            .andExpect(status().is(401));
+      }
+
+    }
+
+
+  }
+
+  private MultiValueMap<String, String> createInfo(String lessonId, String date) {
+    MultiValueMap<String, String> info = new LinkedMultiValueMap<>();
+    info.add("lessonId", lessonId);
+    info.add("date", date);
+    return info;
+  }
+
+  private List<InHomeworkContent> createListRandomSizeBetween(int min, int max) {
+    Integer size = integers().between(min, max).sample();
+    return MONKEY.giveMeBuilder(InHomeworkContent.class).sampleList(size);
+  }
+
+
+
+
+
+
+}

--- a/src/test/java/com/noti/noti/homework/adapter/out/persistence/HomeworkPersistenceAdapterTest.java
+++ b/src/test/java/com/noti/noti/homework/adapter/out/persistence/HomeworkPersistenceAdapterTest.java
@@ -5,12 +5,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 import com.noti.noti.book.adapter.out.persistence.BookMapper;
 import com.noti.noti.common.adapter.out.persistance.DaySetConvertor;
 import com.noti.noti.config.QuerydslTestConfig;
+import com.noti.noti.homework.application.port.out.OutHomeworkContent;
 import com.noti.noti.homework.application.port.out.TodayHomeworkCondition;
 import com.noti.noti.homework.application.port.out.TodaysHomework;
 import com.noti.noti.lesson.adapter.out.persistence.LessonMapper;
 import com.noti.noti.teacher.adpater.out.persistence.TeacherMapper;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.Month;
+import java.time.format.DateTimeFormatter;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -96,6 +99,39 @@ class HomeworkPersistenceAdapterTest {
         assertThat(todaysHomeworks).isNotEmpty();
       }
     }
+  }
+
+  @Nested
+  class findHomeworkContents_메소드는{
+
+    @Nested
+    class 수업_id와_날짜에_해당하는_숙제리스트가_있다면 {
+
+      Long lessonId = 1L;
+      LocalDateTime date = LocalDate.parse(LocalDate.now().toString(), DateTimeFormatter.ISO_DATE).atStartOfDay();
+
+      @Sql("/data/student-homework.sql")
+      @Test
+      void 해당_숙제내용_리스트를_반환한다() {
+        List<OutHomeworkContent> homeworkContents = homeworkPersistenceAdapter.findHomeworkContents(lessonId, date);
+        assertThat(homeworkContents.size()).isEqualTo(3);
+      }
+    }
+
+    @Nested
+    class 수업_id와_날짜에_해당하는_숙제리스트가_없다면 {
+
+      Long lessonId = 5L;
+      LocalDateTime date = LocalDate.parse(LocalDate.now().toString(), DateTimeFormatter.ISO_DATE).atStartOfDay();
+
+      @Sql("/data/student-homework.sql")
+      @Test
+      void 빈_리스트를_반환한다() {
+        List<OutHomeworkContent> homeworkContents = homeworkPersistenceAdapter.findHomeworkContents(lessonId, date);
+        assertThat(homeworkContents.size()).isEqualTo(0);
+      }
+    }
+
   }
 
 

--- a/src/test/java/com/noti/noti/homework/application/port/in/HomeworkContentCommandTest.java
+++ b/src/test/java/com/noti/noti/homework/application/port/in/HomeworkContentCommandTest.java
@@ -1,0 +1,54 @@
+package com.noti.noti.homework.application.port.in;
+
+import static com.noti.noti.common.MonkeyUtils.MONKEY;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+
+import java.time.DateTimeException;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.mockito.Mockito;
+
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@DisplayName("HomeworkContentCommandTest 클래스")
+class HomeworkContentCommandTest {
+
+  @Nested
+  class 모든_조건이_충족되면 {
+    @Test
+    void date값은_String에서_localDateTime으로_변환되어_저장된다() {
+      LocalDate localDate = MONKEY.giveMeBuilder(LocalDate.class).sample();
+
+      HomeworkContentCommand command = new HomeworkContentCommand(Mockito.anyLong(),
+          localDate.toString());
+
+      assertThat(command.getDate()).isInstanceOf(LocalDateTime.class);
+    }
+    @Test
+    void date값은_주어진_날짜의_자정으로_변환된다() {
+      LocalDate localDate = MONKEY.giveMeBuilder(LocalDate.class).sample();
+      LocalDateTime localDateTime = localDate.atStartOfDay();
+
+      HomeworkContentCommand command = new HomeworkContentCommand(Mockito.anyLong(),
+          localDate.toString());
+
+      assertThat(command.getDate()).isEqualTo(localDateTime);
+    }
+  }
+
+
+  @Nested
+  class 파라미터에_잘못된_값이_들어간다면 {
+    @Test
+    void date에_존재하지_않는_날짜가_들어간다면_DateTimeException() {
+      assertThatThrownBy(() -> new HomeworkContentCommand(Mockito.anyLong(), "2022-02-35"))
+          .isInstanceOf(DateTimeException.class);
+    }
+  }
+
+}

--- a/src/test/java/com/noti/noti/homework/application/port/in/HomeworkContentCommandTest.java
+++ b/src/test/java/com/noti/noti/homework/application/port/in/HomeworkContentCommandTest.java
@@ -25,7 +25,7 @@ class HomeworkContentCommandTest {
       LocalDate localDate = MONKEY.giveMeBuilder(LocalDate.class).sample();
 
       HomeworkContentCommand command = new HomeworkContentCommand(Mockito.anyLong(),
-          localDate.toString());
+          localDate);
 
       assertThat(command.getDate()).isInstanceOf(LocalDateTime.class);
     }
@@ -35,19 +35,9 @@ class HomeworkContentCommandTest {
       LocalDateTime localDateTime = localDate.atStartOfDay();
 
       HomeworkContentCommand command = new HomeworkContentCommand(Mockito.anyLong(),
-          localDate.toString());
+          localDate);
 
       assertThat(command.getDate()).isEqualTo(localDateTime);
-    }
-  }
-
-
-  @Nested
-  class 파라미터에_잘못된_값이_들어간다면 {
-    @Test
-    void date에_존재하지_않는_날짜가_들어간다면_DateTimeException() {
-      assertThatThrownBy(() -> new HomeworkContentCommand(Mockito.anyLong(), "2022-02-35"))
-          .isInstanceOf(DateTimeException.class);
     }
   }
 

--- a/src/test/java/com/noti/noti/homework/application/service/GetFilteredHomeworkServiceTest.java
+++ b/src/test/java/com/noti/noti/homework/application/service/GetFilteredHomeworkServiceTest.java
@@ -1,17 +1,28 @@
 package com.noti.noti.homework.application.service;
 
 
+import static com.noti.noti.common.MonkeyUtils.MONKEY;
+import static net.jqwik.api.Arbitraries.integers;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.InstanceOfAssertFactories.LOCAL_DATE_TIME;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
+import com.noti.noti.common.MonkeyUtils;
 import com.noti.noti.homework.application.port.in.FilteredHomeworkCommand;
+import com.noti.noti.homework.application.port.in.HomeworkContentCommand;
 import com.noti.noti.homework.application.port.in.InFilteredHomeworkFrequency;
+import com.noti.noti.homework.application.port.in.InHomeworkContent;
 import com.noti.noti.homework.application.port.out.FindFilteredHomeworkPort;
+import com.noti.noti.homework.application.port.out.FindHomeworkContentPort;
 import com.noti.noti.homework.application.port.out.OutFilteredHomeworkFrequency;
+import com.noti.noti.homework.application.port.out.OutHomeworkContent;
 import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
+import org.assertj.core.api.AbstractListAssert;
+import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
@@ -29,6 +40,9 @@ class GetFilteredHomeworkServiceTest {
 
   @Mock
   FindFilteredHomeworkPort findFilteredHomeworkPort;
+
+  @Mock
+  FindHomeworkContentPort findHomeworkContentPort;
 
   List<OutFilteredHomeworkFrequency> createOutList() {
     OutFilteredHomeworkFrequency out1 = new OutFilteredHomeworkFrequency(
@@ -77,6 +91,58 @@ class GetFilteredHomeworkServiceTest {
           .isEmpty();
     }
 
+  }
+
+  @Nested
+  class getHomeworkContents_메서드는 {
+
+    @Nested
+    class 모든_조건을_충족할_때 {
+
+      @Test
+      void Out_리스트와_같은_내용의_In_리스트_반환() {
+        //given
+        List<OutHomeworkContent> outList = createListRandomSizeBetween(1, 10);
+        when(findHomeworkContentPort.findHomeworkContents(anyLong(), any(LocalDateTime.class)))
+            .thenReturn(outList);
+
+        //when
+        HomeworkContentCommand command = MONKEY.giveMeBuilder(HomeworkContentCommand.class)
+            .setNotNull("lessonId")
+            .setNotNull("date")
+            .sample();
+
+        List<InHomeworkContent> inList = getFilteredHomeworkService.getHomeworkContents(command);
+
+        //then
+        assertThat(inList).usingRecursiveComparison().isEqualTo(outList);
+
+      }
+
+      @Test
+      void 비어있는_리스트_반환() {
+        //given
+        List<OutHomeworkContent> outList = createListRandomSizeBetween(0, 0);
+        when(findHomeworkContentPort.findHomeworkContents(anyLong(), any(LocalDateTime.class)))
+            .thenReturn(outList);
+
+        //when
+        HomeworkContentCommand command = MONKEY.giveMeBuilder(HomeworkContentCommand.class)
+            .setNotNull("lessonId")
+            .setNotNull("date")
+            .sample();
+
+        List<InHomeworkContent> inList = getFilteredHomeworkService.getHomeworkContents(command);
+
+        //then
+        assertThat(inList).isEmpty();
+      }
+    }
+  }
+
+  private List<OutHomeworkContent> createListRandomSizeBetween(int min, int max) {
+    Integer size = integers().between(min, max).sample();
+    return MONKEY.giveMeBuilder(OutHomeworkContent.class).sampleList(size);
   }
 
 }

--- a/src/test/java/com/noti/noti/homework/application/service/GetFilteredHomeworkServiceTest.java
+++ b/src/test/java/com/noti/noti/homework/application/service/GetFilteredHomeworkServiceTest.java
@@ -1,26 +1,16 @@
 package com.noti.noti.homework.application.service;
 
 
-import static com.noti.noti.common.MonkeyUtils.MONKEY;
-import static net.jqwik.api.Arbitraries.integers;
 import static org.assertj.core.api.Assertions.assertThat;
-import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyLong;
 import static org.mockito.Mockito.when;
 
 import com.noti.noti.homework.application.port.in.FilteredHomeworkCommand;
-import com.noti.noti.homework.application.port.in.HomeworkContentCommand;
 import com.noti.noti.homework.application.port.in.InFilteredHomeworkFrequency;
-import com.noti.noti.homework.application.port.in.InHomeworkContent;
 import com.noti.noti.homework.application.port.out.FindFilteredHomeworkPort;
-import com.noti.noti.homework.application.port.out.FindHomeworkContentPort;
 import com.noti.noti.homework.application.port.out.OutFilteredHomeworkFrequency;
-import com.noti.noti.homework.application.port.out.OutHomeworkContent;
-import com.noti.noti.lesson.application.port.out.CheckLessonExistencePort;
-import com.noti.noti.lesson.exception.LessonNotFoundException;
 import java.time.LocalDate;
-import java.time.LocalDateTime;
 import java.util.List;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -44,11 +34,6 @@ class GetFilteredHomeworkServiceTest {
   @Mock
   FindFilteredHomeworkPort findFilteredHomeworkPort;
 
-  @Mock
-  FindHomeworkContentPort findHomeworkContentPort;
-
-  @Mock
-  CheckLessonExistencePort checkLessonExistencePort;
 
   List<OutFilteredHomeworkFrequency> createOutList() {
     OutFilteredHomeworkFrequency out1 = new OutFilteredHomeworkFrequency(
@@ -99,77 +84,5 @@ class GetFilteredHomeworkServiceTest {
 
   }
 
-  @Nested
-  class getHomeworkContents_메서드는 {
-
-    @Nested
-    class 모든_조건을_충족할_때 {
-
-      @Test
-      void Out_리스트와_같은_내용의_In_리스트_반환() {
-        //given
-        HomeworkContentCommand command = MONKEY.giveMeBuilder(HomeworkContentCommand.class)
-            .setNotNull("lessonId")
-            .setNotNull("date")
-            .sample();
-        List<OutHomeworkContent> outList = createListRandomSizeBetween(1, 10);
-
-        when(checkLessonExistencePort.existsById(anyLong())).thenReturn(true);
-        when(findHomeworkContentPort.findHomeworkContents(anyLong(), any(LocalDateTime.class)))
-            .thenReturn(outList);
-
-        //when
-        List<InHomeworkContent> inList = getFilteredHomeworkService.getHomeworkContents(command);
-
-        //then
-        assertThat(inList).usingRecursiveComparison().isEqualTo(outList);
-      }
-
-      @Test
-      void 비어있는_리스트_반환() {
-        //given
-        HomeworkContentCommand command = MONKEY.giveMeBuilder(HomeworkContentCommand.class)
-            .setNotNull("lessonId")
-            .setNotNull("date")
-            .sample();
-        List<OutHomeworkContent> outList = createListRandomSizeBetween(0, 0);
-
-        when(checkLessonExistencePort.existsById(anyLong())).thenReturn(true);
-        when(findHomeworkContentPort.findHomeworkContents(anyLong(), any(LocalDateTime.class)))
-            .thenReturn(outList);
-
-        //when
-        List<InHomeworkContent> inList = getFilteredHomeworkService.getHomeworkContents(command);
-
-        //then
-        assertThat(inList).isEmpty();
-      }
-    }
-
-    @Nested
-    class 조건을_충족하지_않을_때 {
-      @Test
-      void lessonId에_해당하는_수업이_없다면_예외발생() {
-        //given
-        HomeworkContentCommand command = MONKEY.giveMeBuilder(HomeworkContentCommand.class)
-            .setNotNull("lessonId")
-            .setNotNull("date")
-            .sample();
-
-        when(checkLessonExistencePort.existsById(anyLong())).thenReturn(false);
-
-        //when
-        //then
-        assertThatThrownBy(
-            () -> getFilteredHomeworkService.getHomeworkContents(command)
-        ).isInstanceOf(LessonNotFoundException.class);
-      }
-    }
-  }
-
-  private List<OutHomeworkContent> createListRandomSizeBetween(int min, int max) {
-    Integer size = integers().between(min, max).sample();
-    return MONKEY.giveMeBuilder(OutHomeworkContent.class).sampleList(size);
-  }
 
 }

--- a/src/test/java/com/noti/noti/homework/application/service/GetHomeworkContentServiceTest.java
+++ b/src/test/java/com/noti/noti/homework/application/service/GetHomeworkContentServiceTest.java
@@ -1,0 +1,118 @@
+package com.noti.noti.homework.application.service;
+
+import static com.noti.noti.common.MonkeyUtils.MONKEY;
+import static net.jqwik.api.Arbitraries.integers;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.when;
+
+import com.noti.noti.homework.application.port.in.HomeworkContentCommand;
+import com.noti.noti.homework.application.port.in.InHomeworkContent;
+import com.noti.noti.homework.application.port.out.FindHomeworkContentPort;
+import com.noti.noti.homework.application.port.out.OutHomeworkContent;
+import com.noti.noti.lesson.application.port.out.CheckLessonExistencePort;
+import com.noti.noti.lesson.exception.LessonNotFoundException;
+import java.time.LocalDateTime;
+import java.util.List;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@DisplayName("GetHomeworkContentServiceTest 클래스")
+class GetHomeworkContentServiceTest {
+
+  @InjectMocks
+  GetHomeworkContentService getHomeworkContentService;
+
+  @Mock
+  FindHomeworkContentPort findHomeworkContentPort;
+
+  @Mock
+  CheckLessonExistencePort checkLessonExistencePort;
+
+  @Nested
+  class getHomeworkContents_메서드는 {
+
+    @Nested
+    class 모든_조건을_충족할_때 {
+
+      @Test
+      void Out_리스트와_같은_내용의_In_리스트_반환() {
+        //given
+        HomeworkContentCommand command = MONKEY.giveMeBuilder(HomeworkContentCommand.class)
+            .setNotNull("lessonId")
+            .setNotNull("date")
+            .sample();
+        List<OutHomeworkContent> outList = createListRandomSizeBetween(1, 10);
+
+        when(checkLessonExistencePort.existsById(anyLong())).thenReturn(true);
+        when(findHomeworkContentPort.findHomeworkContents(anyLong(), any(LocalDateTime.class)))
+            .thenReturn(outList);
+
+        //when
+        List<InHomeworkContent> inList = getHomeworkContentService.getHomeworkContents(command);
+
+        //then
+        assertThat(inList).usingRecursiveComparison().isEqualTo(outList);
+      }
+
+      @Test
+      void 비어있는_리스트_반환() {
+        //given
+        HomeworkContentCommand command = MONKEY.giveMeBuilder(HomeworkContentCommand.class)
+            .setNotNull("lessonId")
+            .setNotNull("date")
+            .sample();
+        List<OutHomeworkContent> outList = createListRandomSizeBetween(0, 0);
+
+        when(checkLessonExistencePort.existsById(anyLong())).thenReturn(true);
+        when(findHomeworkContentPort.findHomeworkContents(anyLong(), any(LocalDateTime.class)))
+            .thenReturn(outList);
+
+        //when
+        List<InHomeworkContent> inList = getHomeworkContentService.getHomeworkContents(command);
+
+        //then
+        assertThat(inList).isEmpty();
+      }
+    }
+
+    @Nested
+    class 조건을_충족하지_않을_때 {
+      @Test
+      void lessonId에_해당하는_수업이_없다면_예외발생() {
+        //given
+        HomeworkContentCommand command = MONKEY.giveMeBuilder(HomeworkContentCommand.class)
+            .setNotNull("lessonId")
+            .setNotNull("date")
+            .sample();
+
+        when(checkLessonExistencePort.existsById(anyLong())).thenReturn(false);
+
+        //when
+        //then
+        assertThatThrownBy(
+            () -> getHomeworkContentService.getHomeworkContents(command)
+        ).isInstanceOf(LessonNotFoundException.class);
+      }
+    }
+  }
+
+  private List<OutHomeworkContent> createListRandomSizeBetween(int min, int max) {
+    Integer size = integers().between(min, max).sample();
+    return MONKEY.giveMeBuilder(OutHomeworkContent.class).sampleList(size);
+  }
+
+
+}


### PR DESCRIPTION
캘린더에서 분반에 관한 필터를 적용한 후, 특정 날짜에 대한 숙제 목록을 조회하는 API를 구현했습니다~!

구현 중 해결하지 못한 부분이 있어요!
인증이 되지 않은 경우 아래와 같이 응답의 바디 부분이 아래와 같이 작성되어야 하는데,
```
{
  "message": "string",
  "status": 0,
  "errors": [
    {
      "field": "string",
      "value": "string",
      "reason": "string"
    }
  ],
  "code": "string"
}
```
테스트 코드를 돌려보니 아래와 같이 헤더에 있는 status는 401이지만, 
응답의 바디 부분이 없어서 위의 응답을 하지 않습니다. 
```
MockHttpServletResponse:
           Status = 401
    Error message = Unauthorized
          Headers = [WWW-Authenticate:"Basic realm="Realm"", X-Content-Type-Options:"nosniff", X-XSS-Protection:"1; mode=block", Cache-Control:"no-cache, no-store, max-age=0, must-revalidate", Pragma:"no-cache", Expires:"0", X-Frame-Options:"DENY"]
     Content type = null
             Body = 
    Forwarded URL = null
   Redirected URL = null
          Cookies = []
```
어떻게 해결해야 할까요??