### PR TITLE
[FEAT] - noti 59 숙제 추가 기능 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,4 @@ out/
 .vscode/
 src/main/resources/**.yaml
 
-!src/main/resources/application-localdb.yaml
-
 .jqwik-database

--- a/build.gradle
+++ b/build.gradle
@@ -72,7 +72,8 @@ dependencies {
 	testImplementation 'org.testcontainers:mysql:1.17.5'
 
 	// 테스트 객체 생성을 위한 Fixture-monkey 추가
- 	testImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:0.4.12'
+ 	testImplementation 'com.navercorp.fixturemonkey:fixture-monkey-starter:0.5.1'
+	testImplementation 'com.navercorp.fixturemonkey:fixture-monkey-javax-validation:0.5.0'
 }
 
 tasks.named('test') {

--- a/src/main/java/com/noti/noti/config/RedisConfig.java
+++ b/src/main/java/com/noti/noti/config/RedisConfig.java
@@ -1,5 +1,7 @@
 package com.noti.noti.config;
 
+import lombok.RequiredArgsConstructor;
+import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
@@ -7,9 +9,24 @@ import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactor
 import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
+@RequiredArgsConstructor
 @EnableRedisRepositories(enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP, keyspaceNotificationsConfigParameter = "")
 public class RedisConfig {
+  private final RedisProperties redisProperties;
 
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory(redisProperties.getHost(), redisProperties.getPort());
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+    return redisTemplate;
+  }
 }

--- a/src/main/java/com/noti/noti/error/ErrorCode.java
+++ b/src/main/java/com/noti/noti/error/ErrorCode.java
@@ -38,8 +38,11 @@ public enum ErrorCode {
   /*
   Book 관련 예외
    */
-  BOOK_NOT_FOUND(404,"B001","해당 책정보가 존재하지 않습니다"),
-  DUPLICATED_TITLE_BOOK(400, "B002", "중복된 교재입니다");
+  BOOK_NOT_FOUND(404, "B001", "해당 책정보가 존재하지 않습니다"),
+  DUPLICATED_TITLE_BOOK(400, "B002", "중복된 교재입니다"),
+
+  // Lesson 예외
+  LESSON_NOT_FOUND(404, "L001", "해당 수업이 존재하지 않습니다");
   private int status;
   private final String code;
   private final String message;

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/controller/AddHomeworksController.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/controller/AddHomeworksController.java
@@ -1,0 +1,29 @@
+package com.noti.noti.homework.adapter.in.web.controller;
+
+import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
+import com.noti.noti.homework.adapter.in.web.request.AddHomeworksRequest;
+import com.noti.noti.homework.application.port.in.AddHomeworksUsecase;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.annotation.AuthenticationPrincipal;
+import org.springframework.security.core.userdetails.UserDetails;
+import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+@RestController
+@RequiredArgsConstructor
+public class AddHomeworksController {
+
+  private final AddHomeworksUsecase addHomeworksUsecase;
+
+  @PostMapping("/api/teacher/homeworks")
+  public ResponseEntity<SuccessResponse> addHomeworks(@AuthenticationPrincipal UserDetails userDetails,
+      @RequestBody AddHomeworksRequest addHomeworksRequest) {
+    Long teacherId = Long.valueOf(userDetails.getUsername());
+    addHomeworksUsecase.addHomeworks(addHomeworksRequest.toCommand(teacherId));
+
+    return new ResponseEntity<>(SuccessResponse.create201SuccessResponse(), HttpStatus.CREATED);
+  }
+}

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/controller/AddHomeworksController.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/controller/AddHomeworksController.java
@@ -3,6 +3,7 @@ package com.noti.noti.homework.adapter.in.web.controller;
 import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
 import com.noti.noti.homework.adapter.in.web.request.AddHomeworksRequest;
 import com.noti.noti.homework.application.port.in.AddHomeworksUsecase;
+import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -20,7 +21,7 @@ public class AddHomeworksController {
 
   @PostMapping("/api/teacher/homeworks")
   public ResponseEntity<SuccessResponse> addHomeworks(@AuthenticationPrincipal UserDetails userDetails,
-      @RequestBody AddHomeworksRequest addHomeworksRequest) {
+      @RequestBody @Valid AddHomeworksRequest addHomeworksRequest) {
     Long teacherId = Long.valueOf(userDetails.getUsername());
     addHomeworksUsecase.addHomeworks(addHomeworksRequest.toCommand(teacherId));
 

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/controller/AddHomeworksController.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/controller/AddHomeworksController.java
@@ -1,8 +1,14 @@
 package com.noti.noti.homework.adapter.in.web.controller;
 
 import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
+import com.noti.noti.error.ErrorResponse;
 import com.noti.noti.homework.adapter.in.web.request.AddHomeworksRequest;
 import com.noti.noti.homework.application.port.in.AddHomeworksUsecase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.Parameter;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
 import javax.validation.Valid;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
@@ -19,6 +25,23 @@ public class AddHomeworksController {
 
   private final AddHomeworksUsecase addHomeworksUsecase;
 
+  @Operation(tags = "숙제 추가 API ", summary = "addHomeworks", description = "숙제 추가",
+      responses = {
+          @ApiResponse(responseCode = "201", description = "성공", useReturnTypeSchema = true),
+          @ApiResponse(responseCode = "500", description = "서버에러", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))}),
+          @ApiResponse(responseCode = "401", description = "인증되지 않은 유저입니다", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))}),
+          @ApiResponse(responseCode = "403", description = "권한이 없습니다", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))}),
+          @ApiResponse(responseCode = "404", description = "존재하지 않는 리소스입니댜", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))})
+      })
+  @Parameter(name = "userDetails", hidden = true)
   @PostMapping("/api/teacher/homeworks")
   public ResponseEntity<SuccessResponse> addHomeworks(@AuthenticationPrincipal UserDetails userDetails,
       @RequestBody @Valid AddHomeworksRequest addHomeworksRequest) {

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/request/AddHomeworksRequest.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/request/AddHomeworksRequest.java
@@ -1,0 +1,39 @@
+package com.noti.noti.homework.adapter.in.web.request;
+
+import com.noti.noti.homework.application.port.in.AddHomeworksCommand;
+import java.time.LocalDateTime;
+import java.util.List;
+import javax.validation.constraints.Min;
+import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
+import lombok.AccessLevel;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor(access = AccessLevel.PROTECTED)
+public class AddHomeworksRequest {
+
+  @Size(min = 1)
+  @NotNull
+  private List<String> homeworkNames;
+
+  @NotNull
+  private LocalDateTime startTime;
+
+  @NotNull
+  private LocalDateTime endTime;
+
+  @NotNull
+  @Min(1)
+  private Long lessonId;
+
+  @NotNull
+  @Min(1)
+  private Long deadlineAlarmSettingTime;
+
+  public AddHomeworksCommand toCommand() {
+    return new AddHomeworksCommand(homeworkNames, startTime, endTime,
+        endTime.minusHours(deadlineAlarmSettingTime), lessonId);
+  }
+}

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/request/AddHomeworksRequest.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/request/AddHomeworksRequest.java
@@ -29,11 +29,11 @@ public class AddHomeworksRequest {
   private Long lessonId;
 
   @NotNull
-  @Min(1)
+  @Min(0)
   private Long deadlineAlarmSettingTime;
 
   public AddHomeworksCommand toCommand() {
-    return new AddHomeworksCommand(homeworkNames, startTime, endTime,
-        endTime.minusHours(deadlineAlarmSettingTime), lessonId);
+    return new AddHomeworksCommand(homeworkNames, startTime, endTime, deadlineAlarmSettingTime,
+        lessonId);
   }
 }

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/request/AddHomeworksRequest.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/request/AddHomeworksRequest.java
@@ -32,8 +32,8 @@ public class AddHomeworksRequest {
   @Min(0)
   private Long deadlineAlarmSettingTime;
 
-  public AddHomeworksCommand toCommand() {
+  public AddHomeworksCommand toCommand(Long teacherId) {
     return new AddHomeworksCommand(homeworkNames, startTime, endTime, deadlineAlarmSettingTime,
-        lessonId);
+        lessonId, teacherId);
   }
 }

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/request/AddHomeworksRequest.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/request/AddHomeworksRequest.java
@@ -1,6 +1,7 @@
 package com.noti.noti.homework.adapter.in.web.request;
 
 import com.noti.noti.homework.application.port.in.AddHomeworksCommand;
+import io.swagger.v3.oas.annotations.media.Schema;
 import java.time.LocalDateTime;
 import java.util.List;
 import javax.validation.constraints.Min;
@@ -16,20 +17,25 @@ import lombok.NoArgsConstructor;
 public class AddHomeworksRequest {
 
   @NotEmpty
+  @Schema(description = "숙제 이름 목록", required = true, example = "[\"수학의 정석 p.14\"]")
   private List<@NotBlank String> homeworkNames;
 
   @NotNull
+  @Schema(description = "숙제 시작 시간", required = true, example = "2023-02-20 12:00:00", type = "string")
   private LocalDateTime startTime;
 
   @NotNull
+  @Schema(description = "숙제 마감 시간", required = true, example = "2023-02-21 12:00:00", type = "string")
   private LocalDateTime endTime;
 
   @NotNull
   @Min(1)
+  @Schema(description = "수업 ID", required = true, example = "1")
   private Long lessonId;
 
   @NotNull
   @Min(0)
+  @Schema(description = "마감 알람 설정 시간", required = true, example = "1")
   private Long deadlineAlarmSettingTime;
 
   public AddHomeworksCommand toCommand(Long teacherId) {

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/request/AddHomeworksRequest.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/request/AddHomeworksRequest.java
@@ -4,8 +4,9 @@ import com.noti.noti.homework.application.port.in.AddHomeworksCommand;
 import java.time.LocalDateTime;
 import java.util.List;
 import javax.validation.constraints.Min;
+import javax.validation.constraints.NotBlank;
+import javax.validation.constraints.NotEmpty;
 import javax.validation.constraints.NotNull;
-import javax.validation.constraints.Size;
 import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.NoArgsConstructor;
@@ -14,9 +15,8 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class AddHomeworksRequest {
 
-  @Size(min = 1)
-  @NotNull
-  private List<String> homeworkNames;
+  @NotEmpty
+  private List<@NotBlank String> homeworkNames;
 
   @NotNull
   private LocalDateTime startTime;

--- a/src/main/java/com/noti/noti/homework/adapter/out/persistence/HomeworkMapper.java
+++ b/src/main/java/com/noti/noti/homework/adapter/out/persistence/HomeworkMapper.java
@@ -1,6 +1,5 @@
 package com.noti.noti.homework.adapter.out.persistence;
 
-import com.noti.noti.book.adapter.out.persistence.BookMapper;
 import com.noti.noti.homework.adapter.out.persistence.jpa.model.HomeworkJpaEntity;
 import com.noti.noti.homework.domain.model.Homework;
 import com.noti.noti.lesson.adapter.out.persistence.LessonMapper;
@@ -15,6 +14,7 @@ public class HomeworkMapper {
   public Homework mapToDomainEntity(HomeworkJpaEntity homeworkJpaEntity){
     return Homework.builder()
         .id(homeworkJpaEntity.getId())
+        .homeworkName(homeworkJpaEntity.getHomeworkName())
         .lesson(lessonMapper.mapToDomainEntity(homeworkJpaEntity.getLessonJpaEntity()))
         .startTime(homeworkJpaEntity.getStartTime())
         .endTime(homeworkJpaEntity.getEndTime())
@@ -24,7 +24,7 @@ public class HomeworkMapper {
   public HomeworkJpaEntity mapToJpaEntity(Homework homework) {
     return HomeworkJpaEntity.builder()
         .id(homework.getId())
-        .content(homework.getContent())
+        .homeworkName(homework.getHomeworkName())
         .lessonJpaEntity(lessonMapper.mapToJpaEntity(homework.getLesson()))
         .startTime(homework.getStartTime())
         .endTime(homework.getEndTime())

--- a/src/main/java/com/noti/noti/homework/adapter/out/persistence/HomeworkPersistenceAdapter.java
+++ b/src/main/java/com/noti/noti/homework/adapter/out/persistence/HomeworkPersistenceAdapter.java
@@ -1,24 +1,71 @@
 package com.noti.noti.homework.adapter.out.persistence;
 
 import com.noti.noti.homework.adapter.out.persistence.jpa.HomeworkJpaRepository;
+import com.noti.noti.homework.adapter.out.persistence.jpa.model.HomeworkJpaEntity;
 import com.noti.noti.homework.application.port.out.FindTodaysHomeworkPort;
+import com.noti.noti.homework.application.port.out.SaveDeadlineAlarmPort;
+import com.noti.noti.homework.application.port.out.SaveHomeworkPort;
 import com.noti.noti.homework.application.port.out.TodayHomeworkCondition;
 import com.noti.noti.homework.application.port.out.TodaysHomework;
+import com.noti.noti.homework.domain.model.Homework;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
 import java.util.List;
+import java.util.stream.Collectors;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.stereotype.Component;
+import org.springframework.transaction.annotation.Transactional;
 
 @Component
 @RequiredArgsConstructor
-public class HomeworkPersistenceAdapter implements FindTodaysHomeworkPort {
+@Transactional(readOnly = true)
+public class HomeworkPersistenceAdapter implements FindTodaysHomeworkPort, SaveHomeworkPort,
+    SaveDeadlineAlarmPort {
 
   private final HomeworkMapper homeworkMapper;
   private final HomeworkJpaRepository homeworkJpaRepository;
   private final HomeworkQueryRepository homeworkQueryRepository;
+  private final StringRedisTemplate redisTemplate;
 
   @Override
   public List<TodaysHomework> findTodaysHomeworks(TodayHomeworkCondition condition) {
     return homeworkQueryRepository.findTodayHomeworks(condition);
   }
 
+  @Transactional
+  @Override
+  public List<Long> saveAllHomeworks(List<Homework> homeworks) {
+    List<HomeworkJpaEntity> homeworkJpaEntities = homeworks.stream()
+        .map(homeworkMapper::mapToJpaEntity)
+        .collect(Collectors.toList());
+
+    return homeworkJpaRepository.saveAll(homeworkJpaEntities)
+        .stream()
+        .map(HomeworkJpaEntity::getId)
+        .collect(Collectors.toList());
+  }
+
+  @Override
+  public void saveDeadlineAlarm(Long homeworkId, LocalDateTime deadlineAlarmTime) {
+    final String homeworkDeadlineAlarmKey = "homeworkDeadlineAlarm:" + homeworkId;
+    ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+    valueOperations.set(homeworkDeadlineAlarmKey, homeworkId.toString());
+    redisTemplate.expireAt(homeworkDeadlineAlarmKey, Timestamp.valueOf(deadlineAlarmTime));
+  }
+
+//  public void tempMethod(final List<Homework> homeworks) {
+//    final String QUERY =
+//        "insert into teacher "
+//            + "(email, nickname, profile, role, social_id, social_type) "
+//            + "values (1, 1, 1, ?, 123, ?)";
+//
+//    jdbcTemplate.batchUpdate(QUERY, homeworks, 50,
+//        (PreparedStatement ps, Homework homework) -> {
+//          ps.setString(1, "ROLE_TEACHER");
+//          ps.setString(2, "KAKAO");
+//        }
+//    );
+//  }
 }

--- a/src/main/java/com/noti/noti/homework/application/port/in/AddHomeworksCommand.java
+++ b/src/main/java/com/noti/noti/homework/application/port/in/AddHomeworksCommand.java
@@ -12,13 +12,15 @@ public class AddHomeworksCommand {
   private LocalDateTime endTime;
   private Long deadlineAlarmSettingTime;
   private Long lessonId;
+  private Long teacherId;
 
   public AddHomeworksCommand(List<String> homeworkNames, LocalDateTime startTime,
-      LocalDateTime endTime, Long deadlineAlarmSettingTime, Long lessonId) {
+      LocalDateTime endTime, Long deadlineAlarmSettingTime, Long lessonId, Long teacherId) {
     this.homeworkNames = homeworkNames;
     this.startTime = startTime;
     this.endTime = endTime;
     this.deadlineAlarmSettingTime = deadlineAlarmSettingTime;
     this.lessonId = lessonId;
+    this.teacherId = teacherId;
   }
 }

--- a/src/main/java/com/noti/noti/homework/application/port/in/AddHomeworksCommand.java
+++ b/src/main/java/com/noti/noti/homework/application/port/in/AddHomeworksCommand.java
@@ -1,0 +1,24 @@
+package com.noti.noti.homework.application.port.in;
+
+import java.time.LocalDateTime;
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class AddHomeworksCommand {
+
+  private List<String> homeworkNames;
+  private LocalDateTime startTime;
+  private LocalDateTime endTime;
+  private Long deadlineAlarmSettingTime;
+  private Long lessonId;
+
+  public AddHomeworksCommand(List<String> homeworkNames, LocalDateTime startTime,
+      LocalDateTime endTime, Long deadlineAlarmSettingTime, Long lessonId) {
+    this.homeworkNames = homeworkNames;
+    this.startTime = startTime;
+    this.endTime = endTime;
+    this.deadlineAlarmSettingTime = deadlineAlarmSettingTime;
+    this.lessonId = lessonId;
+  }
+}

--- a/src/main/java/com/noti/noti/homework/application/port/in/AddHomeworksCommand.java
+++ b/src/main/java/com/noti/noti/homework/application/port/in/AddHomeworksCommand.java
@@ -3,8 +3,10 @@ package com.noti.noti.homework.application.port.in;
 import java.time.LocalDateTime;
 import java.util.List;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class AddHomeworksCommand {
 
   private List<String> homeworkNames;

--- a/src/main/java/com/noti/noti/homework/application/port/in/AddHomeworksUsecase.java
+++ b/src/main/java/com/noti/noti/homework/application/port/in/AddHomeworksUsecase.java
@@ -1,0 +1,10 @@
+package com.noti.noti.homework.application.port.in;
+
+import com.noti.noti.homework.domain.model.Homework;
+import java.util.List;
+import java.util.function.Function;
+
+public interface AddHomeworksUsecase {
+
+  void addHomeworks(AddHomeworksCommand addHomeworksCommand);
+}

--- a/src/main/java/com/noti/noti/homework/application/port/out/SaveDeadlineAlarmPort.java
+++ b/src/main/java/com/noti/noti/homework/application/port/out/SaveDeadlineAlarmPort.java
@@ -1,0 +1,8 @@
+package com.noti.noti.homework.application.port.out;
+
+import java.time.LocalDateTime;
+
+public interface SaveDeadlineAlarmPort {
+
+  void saveDeadlineAlarm(Long homeworkId, LocalDateTime deadlineAlarmTime);
+}

--- a/src/main/java/com/noti/noti/homework/application/port/out/SaveHomeworkPort.java
+++ b/src/main/java/com/noti/noti/homework/application/port/out/SaveHomeworkPort.java
@@ -1,9 +1,9 @@
 package com.noti.noti.homework.application.port.out;
 
 import com.noti.noti.homework.domain.model.Homework;
+import java.util.List;
 
 public interface SaveHomeworkPort {
 
-  Homework saveHomework(Homework homework);
-
+  List<Long> saveAllHomeworks(List<Homework> homeworks);
 }

--- a/src/main/java/com/noti/noti/homework/application/port/out/SaveHomeworkPort.java
+++ b/src/main/java/com/noti/noti/homework/application/port/out/SaveHomeworkPort.java
@@ -1,0 +1,9 @@
+package com.noti.noti.homework.application.port.out;
+
+import com.noti.noti.homework.domain.model.Homework;
+
+public interface SaveHomeworkPort {
+
+  Homework saveHomework(Homework homework);
+
+}

--- a/src/main/java/com/noti/noti/homework/application/service/AddHomeworksService.java
+++ b/src/main/java/com/noti/noti/homework/application/service/AddHomeworksService.java
@@ -1,0 +1,124 @@
+package com.noti.noti.homework.application.service;
+
+import com.noti.noti.homework.application.port.in.AddHomeworksCommand;
+import com.noti.noti.homework.application.port.in.AddHomeworksUsecase;
+import com.noti.noti.homework.application.port.out.SaveDeadlineAlarmPort;
+import com.noti.noti.homework.application.port.out.SaveHomeworkPort;
+import com.noti.noti.homework.domain.model.Homework;
+import com.noti.noti.lesson.application.exception.LessonNotFoundException;
+import com.noti.noti.lesson.application.port.out.FindLessonPort;
+import com.noti.noti.lesson.application.port.out.StudentsInLesson;
+import com.noti.noti.lesson.domain.model.Lesson;
+import com.noti.noti.student.domain.model.Student;
+import com.noti.noti.studenthomework.application.port.out.SaveStudentHomeworkPort;
+import com.noti.noti.studenthomework.domain.model.StudentHomework;
+import com.noti.noti.teacher.domain.Teacher;
+import java.util.List;
+import java.util.stream.Collectors;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
+
+/**
+ * 숙제를 추가하는 서비스 클래스 입니다. 숙제 존재 여부와 숙제에 해당하는 학생의 id 목록을 조회하고 숙제가 유효하면 요청 받은 숙제추가 정보로 숙제를 생성합니다. 숙제를
+ * 생성한 이후에 StudentHomework를 저장하고 알람시간를 세팅했다면 숙제의 알람 정보를 저장합니다.
+ *
+ * @author 임호준
+ */
+@Service
+@RequiredArgsConstructor
+class AddHomeworksService implements AddHomeworksUsecase {
+
+  private final FindLessonPort findLessonPort;
+  private final SaveHomeworkPort saveHomeworkPort;
+  private final SaveStudentHomeworkPort saveStudentHomeworkPort;
+  private final SaveDeadlineAlarmPort saveDeadlineAlarmPort;
+
+  @Transactional
+  @Override
+  public void addHomeworks(AddHomeworksCommand addHomeworksCommand) {
+    StudentsInLesson studentsInLesson = findLessonAndStudent(addHomeworksCommand.getLessonId());
+
+    List<Long> savedHomeworkIds = saveHomeworkPort.saveAllHomeworks(
+        generateHomeworks(addHomeworksCommand));
+
+    saveAllStudentHomeworks(studentsInLesson, savedHomeworkIds);
+
+    saveAlarm(addHomeworksCommand, savedHomeworkIds);
+  }
+
+  /**
+   * 숙제 도메인 리스트를 생성하는 메서드
+   * @param addHomeworksCommand 숙제추가 command 클래스
+   * @return Homework 리스트를 반환
+   */
+  private List<Homework> generateHomeworks(AddHomeworksCommand addHomeworksCommand) {
+    return addHomeworksCommand.getHomeworkNames().stream()
+        .map(homeworkName -> Homework.builder()
+            .homeworkName(homeworkName)
+            .endTime(addHomeworksCommand.getEndTime())
+            .startTime(addHomeworksCommand.getStartTime())
+            .lesson(Lesson.builder().id(addHomeworksCommand.getLessonId())
+                .teacher(Teacher.builder()
+                    .id(addHomeworksCommand.getTeacherId()).build()).build())
+            .build())
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * student id와 homework id에 해당하는 StudentHomework 목록 생성 메서드
+   * @param studentIds 학생 id 리스트
+   * @param homeworkIds 숙제 id 리스트
+   * @return StudentHomework 리스트
+   */
+  private List<StudentHomework> generateStudentHomeworks(List<Long> studentIds,
+      List<Long> homeworkIds) {
+    return studentIds.stream()
+        .flatMap(studentId -> homeworkIds.stream()
+            .map(homeworkId -> StudentHomework.builder()
+                .student(Student.builder().id(studentId).build())
+                .homework(Homework.builder().id(homeworkId).build())
+                .build()))
+        .collect(Collectors.toList());
+  }
+
+  /**
+   * 수업의 학생 목록의 조회 결과에서 student id 리스트가 비어있지 않으면 studentHomework를 생성해 저장하는 메서드
+   * @param studentsInLesson 수업의 학생
+   * @param savedHomeworkIds 저장된 숙제의 id 리스트
+   */
+  private void saveAllStudentHomeworks(StudentsInLesson studentsInLesson,
+      List<Long> savedHomeworkIds) {
+    if (!studentsInLesson.getStudentIds().isEmpty()) {
+      saveStudentHomeworkPort.saveAllStudentHomeworks(
+          generateStudentHomeworks(studentsInLesson.getStudentIds(), savedHomeworkIds));
+    }
+  }
+
+  /**
+   * 알람시간이 세팅되어 있으면 숙제의 알람정보를 저장하는 메서드
+   * @param addHomeworksCommand 숙제 생성 command
+   * @param homeworkIds 숙제 id 리스트
+   */
+  private void saveAlarm(AddHomeworksCommand addHomeworksCommand, List<Long> homeworkIds) {
+    if (addHomeworksCommand.getDeadlineAlarmSettingTime() != 0) {
+      for (Long homeworkId : homeworkIds) {
+        saveDeadlineAlarmPort.saveDeadlineAlarm(homeworkId,
+            addHomeworksCommand.getEndTime().minusHours(
+                addHomeworksCommand.getDeadlineAlarmSettingTime()));
+      }
+    }
+  }
+
+  /**
+   * 수업 id로 수업의 존재여부와 수업의 학생 id를 조회하는 메서드
+   * @param lessonId 수업의 id
+   * @return 수업의 id와 수업에 해당하는 학생 id 리스트를 가지는 class
+   * @throws LessonNotFoundException
+   *         수업 id에 해당하는 수업이 존재하지 않는 경우
+   */
+  private StudentsInLesson findLessonAndStudent(Long lessonId) {
+    return findLessonPort.findLessonAndStudentsById(lessonId)
+        .orElseThrow(LessonNotFoundException::new);
+  }
+}

--- a/src/main/java/com/noti/noti/homework/domain/model/Homework.java
+++ b/src/main/java/com/noti/noti/homework/domain/model/Homework.java
@@ -1,6 +1,5 @@
 package com.noti.noti.homework.domain.model;
 
-import com.noti.noti.book.domain.model.Book;
 import com.noti.noti.lesson.domain.model.Lesson;
 import java.time.LocalDateTime;
 import lombok.Builder;
@@ -12,16 +11,16 @@ import lombok.NoArgsConstructor;
 public class Homework {
 
   private Long id;
-  private String content;
+  private String homeworkName;
   private LocalDateTime startTime;
   private LocalDateTime endTime;
   private Lesson lesson;
 
   @Builder
-  public Homework(Long id, String content, LocalDateTime startTime, LocalDateTime endTime,
+  public Homework(Long id, String homeworkName, LocalDateTime startTime, LocalDateTime endTime,
       Lesson lesson) {
     this.id = id;
-    this.content = content;
+    this.homeworkName = homeworkName;
     this.startTime = startTime;
     this.endTime = endTime;
     this.lesson = lesson;

--- a/src/main/java/com/noti/noti/homework/domain/model/Homework.java
+++ b/src/main/java/com/noti/noti/homework/domain/model/Homework.java
@@ -5,8 +5,10 @@ import com.noti.noti.lesson.domain.model.Lesson;
 import java.time.LocalDateTime;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class Homework {
 
   private Long id;

--- a/src/main/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapter.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapter.java
@@ -9,6 +9,7 @@ import com.noti.noti.lesson.application.port.out.FrequencyOfLessons;
 import com.noti.noti.lesson.application.port.out.FrequencyOfLessonsPort;
 import com.noti.noti.lesson.application.port.out.LessonDto;
 import com.noti.noti.lesson.application.port.out.SaveLessonPort;
+import com.noti.noti.lesson.application.port.out.StudentsInLesson;
 import com.noti.noti.lesson.application.port.out.TodaysLesson;
 import com.noti.noti.lesson.application.port.out.TodaysLessonSearchConditon;
 import com.noti.noti.lesson.domain.model.Lesson;
@@ -43,6 +44,11 @@ class LessonPersistenceAdapter implements SaveLessonPort, FindLessonPort,
   @Override
   public List<LessonDto> findAllLessonsByTeacherId(Long teacherId) {
     return lessonQueryRepository.findAllLessonsByTeacherId(teacherId);
+  }
+
+  @Override
+  public Optional<StudentsInLesson> findLessonAndStudentsById(Long lessonId) {
+    return lessonQueryRepository.findLessonAndStudentsById(lessonId);
   }
 
   @Override

--- a/src/main/java/com/noti/noti/lesson/application/exception/LessonNotFoundException.java
+++ b/src/main/java/com/noti/noti/lesson/application/exception/LessonNotFoundException.java
@@ -1,0 +1,11 @@
+package com.noti.noti.lesson.application.exception;
+
+import com.noti.noti.error.ErrorCode;
+import com.noti.noti.error.exception.BusinessException;
+
+public class LessonNotFoundException extends BusinessException {
+
+  public LessonNotFoundException() {
+    super(ErrorCode.LESSON_NOT_FOUND);
+  }
+}

--- a/src/main/java/com/noti/noti/lesson/application/port/out/FindLessonPort.java
+++ b/src/main/java/com/noti/noti/lesson/application/port/out/FindLessonPort.java
@@ -9,4 +9,5 @@ public interface FindLessonPort {
   Optional<Lesson> findById(Long id);
   List<TodaysLesson> findTodaysLessons(TodaysLessonSearchConditon condition);
   List<LessonDto> findAllLessonsByTeacherId(Long teacherId);
+  Optional<StudentsInLesson> findLessonAndStudentsById(Long lessonId);
 }

--- a/src/main/java/com/noti/noti/lesson/application/port/out/StudentsInLesson.java
+++ b/src/main/java/com/noti/noti/lesson/application/port/out/StudentsInLesson.java
@@ -1,0 +1,11 @@
+package com.noti.noti.lesson.application.port.out;
+
+import java.util.List;
+import lombok.Getter;
+
+@Getter
+public class StudentsInLesson {
+
+  private Long lessonId;
+  private List<Long> studentIds;
+}

--- a/src/main/java/com/noti/noti/lesson/domain/model/Lesson.java
+++ b/src/main/java/com/noti/noti/lesson/domain/model/Lesson.java
@@ -7,8 +7,10 @@ import java.time.LocalTime;
 import java.util.Set;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class Lesson {
   private Long id;
   private Teacher teacher;

--- a/src/main/java/com/noti/noti/student/domain/model/Student.java
+++ b/src/main/java/com/noti/noti/student/domain/model/Student.java
@@ -2,8 +2,10 @@ package com.noti.noti.student.domain.model;
 
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class Student {
 
   private Long id;

--- a/src/main/java/com/noti/noti/studenthomework/adapter/out/persistence/StudentHomeworkAdapter.java
+++ b/src/main/java/com/noti/noti/studenthomework/adapter/out/persistence/StudentHomeworkAdapter.java
@@ -3,20 +3,41 @@ package com.noti.noti.studenthomework.adapter.out.persistence;
 import com.noti.noti.studenthomework.adapter.out.persistence.jpa.StudentHomeworkJpaRepository;
 import com.noti.noti.studenthomework.application.port.out.FindHomeworksOfCalendarPort;
 import com.noti.noti.studenthomework.application.port.out.OutHomeworkOfGivenDate;
+import com.noti.noti.studenthomework.application.port.out.SaveStudentHomeworkPort;
+import com.noti.noti.studenthomework.domain.model.StudentHomework;
+import java.sql.PreparedStatement;
 import java.time.LocalDate;
 import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.jdbc.core.JdbcTemplate;
 import org.springframework.stereotype.Component;
 
 @Component
 @RequiredArgsConstructor
-public class StudentHomeworkAdapter implements FindHomeworksOfCalendarPort {
+public class StudentHomeworkAdapter implements FindHomeworksOfCalendarPort,
+    SaveStudentHomeworkPort {
 
   private final StudentHomeworkJpaRepository studentHomeworkJpaRepository;
   private final StudentHomeworkQueryRepository studentHomeworkQueryRepository;
+  private final JdbcTemplate jdbcTemplate;
 
   @Override
   public List<OutHomeworkOfGivenDate> findHomeworksOfCalendar(LocalDate date, Long teacherId) {
     return studentHomeworkQueryRepository.findHomeworkOfCalendar(date.atStartOfDay(), teacherId);
+  }
+
+  @Override
+  public void saveAllStudentHomeworks(List<StudentHomework> studentHomeworks) {
+    final String QUERY =
+        "insert into student_homework "
+            + "(created_at, modified_at, homework_status, homework_id, student_id) "
+            + "values (now(), now(), false, ?, ?)";
+
+    jdbcTemplate.batchUpdate(QUERY, studentHomeworks, 50,
+        (PreparedStatement ps, StudentHomework studentHomework) -> {
+          ps.setLong(1, studentHomework.getHomework().getId());
+          ps.setLong(2, studentHomework.getStudent().getId());
+        }
+    );
   }
 }

--- a/src/main/java/com/noti/noti/studenthomework/application/port/out/SaveStudentHomeworkPort.java
+++ b/src/main/java/com/noti/noti/studenthomework/application/port/out/SaveStudentHomeworkPort.java
@@ -1,0 +1,9 @@
+package com.noti.noti.studenthomework.application.port.out;
+
+import com.noti.noti.studenthomework.domain.model.StudentHomework;
+import java.util.List;
+
+public interface SaveStudentHomeworkPort {
+
+  void saveAllStudentHomeworks(List<StudentHomework> studentHomeworks);
+}

--- a/src/main/java/com/noti/noti/studenthomework/domain/model/StudentHomework.java
+++ b/src/main/java/com/noti/noti/studenthomework/domain/model/StudentHomework.java
@@ -1,12 +1,13 @@
 package com.noti.noti.studenthomework.domain.model;
 
 import com.noti.noti.homework.domain.model.Homework;
-import com.noti.noti.lesson.domain.model.Lesson;
 import com.noti.noti.student.domain.model.Student;
 import lombok.Builder;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class StudentHomework {
   private Long id;
   private boolean homeworkStatus;

--- a/src/main/resources/application-localdb.yaml
+++ b/src/main/resources/application-localdb.yaml
@@ -1,5 +1,0 @@
-spring:
-  datasource:
-    url: jdbc:mysql://localhost:3306/noti
-    driver-class-name: com.mysql.cj.jdbc.Driver
-    username: root

--- a/src/test/java/com/noti/noti/common/MonkeyUtils.java
+++ b/src/test/java/com/noti/noti/common/MonkeyUtils.java
@@ -1,8 +1,8 @@
 package com.noti.noti.common;
 
 import com.navercorp.fixturemonkey.FixtureMonkey;
-import com.navercorp.fixturemonkey.LabMonkey;
 import com.navercorp.fixturemonkey.api.introspector.FieldReflectionArbitraryIntrospector;
+import com.navercorp.fixturemonkey.javax.validation.plugin.JavaxValidationPlugin;
 import com.noti.noti.teacher.domain.Role;
 import com.noti.noti.teacher.domain.Teacher;
 
@@ -18,7 +18,8 @@ public class MonkeyUtils {
 
   private MonkeyUtils() {}
   private static FixtureMonkey monkey() {
-    return LabMonkey.labMonkeyBuilder()
+    return FixtureMonkey.builder()
+        .plugin(new JavaxValidationPlugin())
         .objectIntrospector(FieldReflectionArbitraryIntrospector.INSTANCE)
         .build();
   }

--- a/src/test/java/com/noti/noti/config/RedisTemplateTestConfig.java
+++ b/src/test/java/com/noti/noti/config/RedisTemplateTestConfig.java
@@ -1,0 +1,34 @@
+package com.noti.noti.config;
+
+import org.springframework.boot.test.context.TestConfiguration;
+import org.springframework.context.annotation.Bean;
+import org.springframework.data.redis.connection.RedisConnectionFactory;
+import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.serializer.StringRedisSerializer;
+
+@TestConfiguration
+public class RedisTemplateTestConfig {
+
+  @Bean
+  public RedisConnectionFactory redisConnectionFactory() {
+    return new LettuceConnectionFactory();
+  }
+
+  @Bean
+  public RedisTemplate<String, Object> redisTemplate() {
+    RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+    redisTemplate.setConnectionFactory(redisConnectionFactory());
+    redisTemplate.setDefaultSerializer(new StringRedisSerializer());
+    return redisTemplate;
+  }
+
+  @Bean
+  public StringRedisTemplate stringRedisTemplate(){
+    StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
+    stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
+    stringRedisTemplate.setDefaultSerializer(new StringRedisSerializer());
+    return stringRedisTemplate;
+  }
+}

--- a/src/test/java/com/noti/noti/homework/adapter/in/web/controller/AddHomeworksControllerTest.java
+++ b/src/test/java/com/noti/noti/homework/adapter/in/web/controller/AddHomeworksControllerTest.java
@@ -1,0 +1,92 @@
+package com.noti.noti.homework.adapter.in.web.controller;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.springframework.security.test.web.servlet.request.SecurityMockMvcRequestPostProcessors.csrf;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.post;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.noti.noti.common.MonkeyUtils;
+import com.noti.noti.common.WithAuthUser;
+import com.noti.noti.config.JacksonConfiguration;
+import com.noti.noti.config.security.jwt.filter.CustomJwtFilter;
+import com.noti.noti.homework.adapter.in.web.request.AddHomeworksRequest;
+import com.noti.noti.homework.application.port.in.AddHomeworksUsecase;
+import com.noti.noti.lesson.application.exception.LessonNotFoundException;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.autoconfigure.web.servlet.WebMvcTest;
+import org.springframework.boot.test.mock.mockito.MockBean;
+import org.springframework.context.annotation.ComponentScan;
+import org.springframework.context.annotation.FilterType;
+import org.springframework.context.annotation.Import;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+
+@WebMvcTest(controllers = AddHomeworksController.class,
+    excludeFilters = @ComponentScan.Filter(
+        type = FilterType.ASSIGNABLE_TYPE, classes = CustomJwtFilter.class))
+@DisplayName("AddHomeworksControllerTest 클래스")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@Import(JacksonConfiguration.class)
+class AddHomeworksControllerTest {
+
+  @Autowired
+  MockMvc mockMvc;
+
+  @MockBean
+  AddHomeworksUsecase addHomeworksUsecase;
+
+  @Autowired
+  ObjectMapper objectMapper;
+
+  @WithAuthUser(id = "1", role = "ROLE_TEACHER")
+  @Nested
+  class addHomeworks_메서드는 {
+
+    @Nested
+    class 유효하지_않는_Lesson_ID가_주어지면 {
+
+      @Test
+      void LessonNotFoundException_예외가_발생하고_404_응답을_반환한다() throws Exception {
+        AddHomeworksRequest addHomeworksRequest = MonkeyUtils.MONKEY.giveMeOne(
+            AddHomeworksRequest.class);
+
+        doThrow(new LessonNotFoundException()).when(addHomeworksUsecase).addHomeworks(any());
+        mockMvc.perform(post("/api/teacher/homeworks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(addHomeworksRequest))
+                .with(csrf()))
+            .andExpectAll(
+                status().is4xxClientError(),
+                result -> assertThat(result.getResolvedException()).isInstanceOf(
+                    LessonNotFoundException.class)
+            );
+      }
+    }
+
+    @Nested
+    class 유효한_요청이_주어지면 {
+
+      @Test
+      void 성공적으로_요청을_수행하고_201_응답을_반환한다() throws Exception {
+        AddHomeworksRequest addHomeworksRequest = MonkeyUtils.MONKEY.giveMeOne(
+            AddHomeworksRequest.class);
+
+        doNothing().when(addHomeworksUsecase).addHomeworks(any());
+        mockMvc.perform(post("/api/teacher/homeworks")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(objectMapper.writeValueAsBytes(addHomeworksRequest))
+                .with(csrf()))
+            .andExpect(status().isCreated());
+      }
+    }
+  }
+}

--- a/src/test/java/com/noti/noti/homework/adapter/out/persistence/HomeworkPersistenceAdapterTest.java
+++ b/src/test/java/com/noti/noti/homework/adapter/out/persistence/HomeworkPersistenceAdapterTest.java
@@ -1,14 +1,21 @@
 package com.noti.noti.homework.adapter.out.persistence;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.assertAll;
 
 import com.noti.noti.book.adapter.out.persistence.BookMapper;
+import com.noti.noti.common.MonkeyUtils;
+import com.noti.noti.common.RedisTestContainerConfig;
 import com.noti.noti.common.adapter.out.persistance.DaySetConvertor;
 import com.noti.noti.config.QuerydslTestConfig;
+import com.noti.noti.config.RedisTemplateTestConfig;
 import com.noti.noti.homework.application.port.out.TodayHomeworkCondition;
 import com.noti.noti.homework.application.port.out.TodaysHomework;
+import com.noti.noti.homework.domain.model.Homework;
 import com.noti.noti.lesson.adapter.out.persistence.LessonMapper;
+import com.noti.noti.lesson.domain.model.Lesson;
 import com.noti.noti.teacher.adpater.out.persistence.TeacherMapper;
+import com.noti.noti.teacher.domain.Teacher;
 import java.time.LocalDateTime;
 import java.time.Month;
 import java.util.List;
@@ -21,6 +28,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.autoconfigure.orm.jpa.DataJpaTest;
 import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
 import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
@@ -28,15 +37,60 @@ import org.springframework.test.context.jdbc.Sql;
 @ActiveProfiles("test")
 @Import({HomeworkPersistenceAdapter.class, HomeworkMapper.class, LessonMapper.class,
     BookMapper.class, TeacherMapper.class, DaySetConvertor.class, HomeworkQueryRepository.class,
-    QuerydslTestConfig.class})
+    QuerydslTestConfig.class, RedisTemplateTestConfig.class})
 @DisplayName("HomeworkPersistenceAdapterTest 클래스")
 @DisplayNameGeneration(ReplaceUnderscores.class)
 @Slf4j
-class HomeworkPersistenceAdapterTest {
+class HomeworkPersistenceAdapterTest extends RedisTestContainerConfig {
 
   @Autowired
   HomeworkPersistenceAdapter homeworkPersistenceAdapter;
 
+  @Autowired
+  StringRedisTemplate redisTemplate;
+
+  @Nested
+  class saveDeadlineAlarm_메서드는 {
+
+    @Nested
+    class 만료시간이_현재보다_늦는다면 {
+
+      @Test
+      void 성공적으로_정보를_저장하고_만료시간을_설정한다() {
+        final String key = "homeworkDeadlineAlarm:1";
+        LocalDateTime expireAt = LocalDateTime.now().plusMinutes(1);
+        homeworkPersistenceAdapter.saveDeadlineAlarm(1L, expireAt);
+
+        ValueOperations<String, String> valueOperations = redisTemplate.opsForValue();
+        String value = valueOperations.get(key);
+        Long expire = redisTemplate.getExpire(key);
+        assertAll(
+            () -> assertThat(value).isEqualTo("1"),
+            () -> assertThat(expire).isGreaterThan(0)
+        );
+      }
+    }
+  }
+
+  @Sql("/data/homework.sql")
+  @Nested
+  class saveAllHomeworks_메서드는 {
+
+    @Nested
+    class Homework_리스트가_주어지면 {
+
+      @Test
+      void 성공적으로_객체를_저장하고_저장된_ID를_반환한다() {
+        List<Homework> givenHomeworks = MonkeyUtils.MONKEY.giveMeBuilder(Homework.class)
+            .setNull("id")
+            .set("lesson",
+                Lesson.builder().id(1L).teacher(Teacher.builder().id(1L).build()).build())
+            .sampleList(5);
+        List<Long> savedIds = homeworkPersistenceAdapter.saveAllHomeworks(givenHomeworks);
+        assertThat(savedIds).isNotEmpty();
+      }
+    }
+  }
 
   @Sql("/data/homework.sql")
   @Nested
@@ -46,8 +100,9 @@ class HomeworkPersistenceAdapterTest {
     class 수업이_없는_선생님_ID가_주어지면 {
 
       final TodayHomeworkCondition condition = new TodayHomeworkCondition(3L, LocalDateTime.now());
+
       @Test
-      void 비어있는_List를_반환한다(){
+      void 비어있는_List를_반환한다() {
         List<TodaysHomework> todaysHomeworks = homeworkPersistenceAdapter.findTodaysHomeworks(
             condition);
 
@@ -60,8 +115,9 @@ class HomeworkPersistenceAdapterTest {
 
       final TodayHomeworkCondition condition = new TodayHomeworkCondition(2L,
           LocalDateTime.of(2022, Month.DECEMBER, 31, 12, 00));
+
       @Test
-      void 비어있는_List를_반환한다(){
+      void 비어있는_List를_반환한다() {
         List<TodaysHomework> todaysHomeworks = homeworkPersistenceAdapter.findTodaysHomeworks(
             condition);
 
@@ -74,8 +130,9 @@ class HomeworkPersistenceAdapterTest {
 
       final TodayHomeworkCondition condition = new TodayHomeworkCondition(1L,
           LocalDateTime.of(2023, Month.JANUARY, 2, 12, 00));
+
       @Test
-      void 비어있는_List를_반환한다(){
+      void 비어있는_List를_반환한다() {
         List<TodaysHomework> todaysHomeworks = homeworkPersistenceAdapter.findTodaysHomeworks(
             condition);
 
@@ -88,8 +145,9 @@ class HomeworkPersistenceAdapterTest {
 
       final TodayHomeworkCondition condition = new TodayHomeworkCondition(1L,
           LocalDateTime.now());
+
       @Test
-      void 숙제목록과_숙제에_해당하는_학생목록_List를_반환한다(){
+      void 숙제목록과_숙제에_해당하는_학생목록_List를_반환한다() {
         List<TodaysHomework> todaysHomeworks = homeworkPersistenceAdapter.findTodaysHomeworks(
             condition);
 

--- a/src/test/java/com/noti/noti/homework/application/service/AddHomeworksServiceTest.java
+++ b/src/test/java/com/noti/noti/homework/application/service/AddHomeworksServiceTest.java
@@ -1,0 +1,239 @@
+package com.noti.noti.homework.application.service;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyList;
+import static org.mockito.ArgumentMatchers.anyLong;
+import static org.mockito.Mockito.atLeastOnce;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.noti.noti.common.MonkeyUtils;
+import com.noti.noti.homework.application.port.in.AddHomeworksCommand;
+import com.noti.noti.homework.application.port.out.SaveDeadlineAlarmPort;
+import com.noti.noti.homework.application.port.out.SaveHomeworkPort;
+import com.noti.noti.lesson.application.exception.LessonNotFoundException;
+import com.noti.noti.lesson.application.port.out.FindLessonPort;
+import com.noti.noti.lesson.application.port.out.StudentsInLesson;
+import com.noti.noti.studenthomework.application.port.out.SaveStudentHomeworkPort;
+import java.util.List;
+import java.util.Optional;
+import net.jqwik.api.Arbitraries;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@DisplayName("AddHomeworkServiceTest 클래스")
+class AddHomeworksServiceTest {
+
+  @InjectMocks
+  AddHomeworksService addHomeworksService;
+
+  @Mock
+  FindLessonPort findLessonPort;
+
+  @Mock
+  SaveHomeworkPort saveHomeworkPort;
+
+  @Mock
+  SaveStudentHomeworkPort saveStudentHomeworkPort;
+
+  @Mock
+  SaveDeadlineAlarmPort saveDeadlineAlarmPort;
+
+  @Nested
+  class addHomeworks_메서드는 {
+
+    @Nested
+    class 유효하지_않는_수업_id가_주어지면 {
+
+      @Test
+      void LessonNotFoundException_예외가_발생한다() {
+        AddHomeworksCommand command = MonkeyUtils.MONKEY.giveMeBuilder(AddHomeworksCommand.class)
+            .setNotNull("lessonId").sample();
+        when(findLessonPort.findLessonAndStudentsById(command.getLessonId())).thenReturn(
+            Optional.empty());
+
+        assertAll(
+            () -> assertThatThrownBy(() -> addHomeworksService.addHomeworks(command)).isInstanceOf(
+                LessonNotFoundException.class),
+            () -> verify(saveHomeworkPort, never()).saveAllHomeworks(anyList()),
+            () -> verify(saveStudentHomeworkPort, never()).saveAllStudentHomeworks(anyList()),
+            () -> verify(saveDeadlineAlarmPort, never()).saveDeadlineAlarm(any(), any())
+        );
+      }
+    }
+
+    @Nested
+    class 수업에_해당하는_학생이_존재하지_않고_알람_설정이_되어있지_않으면 {
+
+      @Test
+      void 요청된_숙제_정보를_저장하고_StudentHomework과_알람_정보는_저장하지_않는다() {
+        AddHomeworksCommand command =
+            MonkeyUtils.MONKEY.giveMeBuilder(AddHomeworksCommand.class)
+                .setNotNull("lessonId")
+                .setNotNull("teacherId")
+                .size("homeworkNames", 3)
+                .set("deadlineAlarmSettingTime", 0L)
+                .sample();
+
+        StudentsInLesson studentsInLesson =
+            MonkeyUtils.MONKEY.giveMeBuilder(StudentsInLesson.class)
+                .set("lessonId", command.getLessonId())
+                .size("studentIds", 0)
+                .sample();
+
+        List<Long> savedHomeworkIds = List.of(1L, 2L, 3L);
+
+        when(findLessonPort.findLessonAndStudentsById(command.getLessonId())).thenReturn(
+            Optional.of(studentsInLesson));
+        when(saveHomeworkPort.saveAllHomeworks(anyList())).thenReturn(savedHomeworkIds);
+
+        addHomeworksService.addHomeworks(command);
+        assertAll(
+            () -> verify(findLessonPort, times(1)).findLessonAndStudentsById(
+                command.getLessonId()),
+            () -> verify(saveHomeworkPort, atLeastOnce()).saveAllHomeworks(anyList()),
+            () -> verify(saveStudentHomeworkPort, never()).saveAllStudentHomeworks(anyList()),
+            () -> verify(saveDeadlineAlarmPort, never()).saveDeadlineAlarm(any(), any())
+        );
+      }
+    }
+
+    @Nested
+    class 수업에_해당하는_학생이_존재하지_않고_알람_설정이_되어있으면 {
+
+      @Test
+      void 숙제와_숙제의_알람_정보만_저장한다() {
+        AddHomeworksCommand command =
+            MonkeyUtils.MONKEY.giveMeBuilder(AddHomeworksCommand.class)
+                .setNotNull("lessonId")
+                .setNotNull("teacherId")
+                .setNotNull("endTime")
+                .size("homeworkNames", 3)
+                .set("deadlineAlarmSettingTime", 1L)
+                .sample();
+
+        StudentsInLesson studentsInLesson =
+            MonkeyUtils.MONKEY.giveMeBuilder(StudentsInLesson.class)
+                .set("lessonId", command.getLessonId())
+                .size("studentIds", 0)
+                .sample();
+
+        List<Long> savedHomeworkIds = List.of(1L, 2L, 3L);
+
+        when(findLessonPort.findLessonAndStudentsById(command.getLessonId())).thenReturn(
+            Optional.of(studentsInLesson));
+        when(saveHomeworkPort.saveAllHomeworks(anyList())).thenReturn(savedHomeworkIds);
+        doNothing().when(saveDeadlineAlarmPort).saveDeadlineAlarm(anyLong(), any());
+
+        addHomeworksService.addHomeworks(command);
+        assertAll(
+            () -> verify(findLessonPort, times(1)).findLessonAndStudentsById(
+                command.getLessonId()),
+            () -> verify(saveHomeworkPort, atLeastOnce()).saveAllHomeworks(anyList()),
+            () -> verify(saveStudentHomeworkPort, never()).saveAllStudentHomeworks(anyList()),
+            () -> verify(saveDeadlineAlarmPort, atLeastOnce()).saveDeadlineAlarm(any(), any())
+        );
+      }
+    }
+
+    @Nested
+    class 수업에_해당하는_학생이_존재하고_알람_설정이_되어있으면 {
+
+      @Test
+      void 숙제와_숙제의_알람_정보_StudentHomework를_저장한다() {
+        AddHomeworksCommand command =
+            MonkeyUtils.MONKEY.giveMeBuilder(AddHomeworksCommand.class)
+                .setNotNull("lessonId")
+                .setNotNull("teacherId")
+                .setNotNull("endTime")
+                .size("homeworkNames", 3)
+                .set("deadlineAlarmSettingTime", 1L)
+                .sample();
+
+        List<Long> studentIds =
+            Arbitraries.longs()
+                .between(1L, 10L).list().ofSize(5).uniqueElements()
+                .sample();
+
+        StudentsInLesson studentsInLesson =
+            MonkeyUtils.MONKEY.giveMeBuilder(StudentsInLesson.class)
+                .set("lessonId", command.getLessonId())
+                .set("studentIds", studentIds)
+                .sample();
+
+        List<Long> savedHomeworkIds = List.of(1L, 2L, 3L);
+
+        when(findLessonPort.findLessonAndStudentsById(command.getLessonId())).thenReturn(
+            Optional.of(studentsInLesson));
+        when(saveHomeworkPort.saveAllHomeworks(anyList())).thenReturn(savedHomeworkIds);
+        doNothing().when(saveStudentHomeworkPort).saveAllStudentHomeworks(anyList());
+        doNothing().when(saveDeadlineAlarmPort).saveDeadlineAlarm(anyLong(), any());
+
+        addHomeworksService.addHomeworks(command);
+        assertAll(
+            () -> verify(findLessonPort, times(1)).findLessonAndStudentsById(
+                command.getLessonId()),
+            () -> verify(saveHomeworkPort, atLeastOnce()).saveAllHomeworks(anyList()),
+            () -> verify(saveStudentHomeworkPort, times(1)).saveAllStudentHomeworks(anyList()),
+            () -> verify(saveDeadlineAlarmPort, atLeastOnce()).saveDeadlineAlarm(any(), any())
+        );
+      }
+    }
+
+    @Nested
+    class 수업에_해당하는_학생이_존재하고_알람_설정이_되어있지_않으면 {
+
+      @Test
+      void 숙제와_StudentHomework를_저장한다() {
+        AddHomeworksCommand command =
+            MonkeyUtils.MONKEY.giveMeBuilder(AddHomeworksCommand.class)
+                .setNotNull("lessonId")
+                .setNotNull("teacherId")
+                .size("homeworkNames", 3)
+                .set("deadlineAlarmSettingTime", 0L)
+                .sample();
+
+        List<Long> studentIds =
+            Arbitraries.longs()
+                .between(1L, 10L).list().ofSize(5).uniqueElements()
+                .sample();
+
+        StudentsInLesson studentsInLesson =
+            MonkeyUtils.MONKEY.giveMeBuilder(StudentsInLesson.class)
+                .set("lessonId", command.getLessonId())
+                .set("studentIds", studentIds)
+                .sample();
+
+        List<Long> savedHomeworkIds = List.of(1L, 2L, 3L);
+
+        when(findLessonPort.findLessonAndStudentsById(command.getLessonId())).thenReturn(
+            Optional.of(studentsInLesson));
+        when(saveHomeworkPort.saveAllHomeworks(anyList())).thenReturn(savedHomeworkIds);
+        doNothing().when(saveStudentHomeworkPort).saveAllStudentHomeworks(anyList());
+
+        addHomeworksService.addHomeworks(command);
+        assertAll(
+            () -> verify(findLessonPort, times(1)).findLessonAndStudentsById(
+                command.getLessonId()),
+            () -> verify(saveHomeworkPort, atLeastOnce()).saveAllHomeworks(anyList()),
+            () -> verify(saveStudentHomeworkPort, times(1)).saveAllStudentHomeworks(anyList()),
+            () -> verify(saveDeadlineAlarmPort, never()).saveDeadlineAlarm(any(), any())
+        );
+      }
+    }
+  }
+}

--- a/src/test/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapterTest.java
+++ b/src/test/java/com/noti/noti/lesson/adapter/out/persistence/LessonPersistenceAdapterTest.java
@@ -7,6 +7,7 @@ import com.noti.noti.config.QuerydslTestConfig;
 import com.noti.noti.lesson.application.port.out.FrequencyOfLessons;
 import com.noti.noti.lesson.application.port.out.LessonDto;
 import com.noti.noti.lesson.application.port.out.OutCreatedLesson;
+import com.noti.noti.lesson.application.port.out.StudentsInLesson;
 import com.noti.noti.lesson.application.port.out.TodaysLesson;
 import com.noti.noti.lesson.application.port.out.TodaysLessonSearchConditon;
 import com.noti.noti.lesson.domain.model.Lesson;
@@ -15,6 +16,7 @@ import com.noti.noti.teacher.domain.Teacher;
 import java.time.DayOfWeek;
 import java.time.YearMonth;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -39,6 +41,53 @@ class LessonPersistenceAdapterTest {
 
   @Autowired
   LessonPersistenceAdapter lessonPersistenceAdapter;
+
+  @Sql("/data/lesson.sql")
+  @Nested
+  class findLessonAndStudentsById_메서드는 {
+
+    @Nested
+    class 조건에_해당하는_수업이_존재하지_않으면 {
+
+      @Test
+      void 비어있는_Optional_객체를_반환한다() {
+        Optional<StudentsInLesson> studentsInLesson = lessonPersistenceAdapter
+            .findLessonAndStudentsById(6L);
+
+        assertThat(studentsInLesson).isNotPresent();
+      }
+    }
+
+    @Nested
+    class 조건에_해당하는_수업은_존재하고_학생은_존재하지_않는다면 {
+
+      @Test
+      void studentIds_목록은_비어있는_StudentsInLesson_Optional_객체를_반환한다() {
+        Optional<StudentsInLesson> returnedStudentsInLesson = lessonPersistenceAdapter
+            .findLessonAndStudentsById(4L);
+
+        assertThat(returnedStudentsInLesson)
+            .isPresent()
+            .hasValueSatisfying(studentsInLesson ->
+                assertThat(studentsInLesson.getStudentIds()).isEmpty());
+      }
+    }
+
+    @Nested
+    class 조건에_해당하는_수업과_학생이_존재하면 {
+
+      @Test
+      void 정보가_모두_담긴_StudentsInLesson_Optional_객체를_반환한다() {
+        Optional<StudentsInLesson> returnedStudentsInLesson = lessonPersistenceAdapter
+            .findLessonAndStudentsById(1L);
+
+        assertThat(returnedStudentsInLesson)
+            .isPresent()
+            .hasValueSatisfying(studentsInLesson ->
+                assertThat(studentsInLesson.getStudentIds()).isNotEmpty());
+      }
+    }
+  }
 
   @Nested
   class findAllLessonsByTeacherId_메서드는 {

--- a/src/test/java/com/noti/noti/studenthomework/adapter/out/persistence/StudentHomeworkAdapterTest.java
+++ b/src/test/java/com/noti/noti/studenthomework/adapter/out/persistence/StudentHomeworkAdapterTest.java
@@ -1,9 +1,16 @@
 package com.noti.noti.studenthomework.adapter.out.persistence;
 
+import com.noti.noti.common.MonkeyUtils;
 import com.noti.noti.config.QuerydslTestConfig;
+import com.noti.noti.homework.domain.model.Homework;
+import com.noti.noti.lesson.domain.model.Lesson;
+import com.noti.noti.student.domain.model.Student;
+import com.noti.noti.studenthomework.adapter.out.persistence.jpa.StudentHomeworkJpaRepository;
 import com.noti.noti.studenthomework.application.port.out.OutHomeworkOfGivenDate;
+import com.noti.noti.studenthomework.domain.model.StudentHomework;
 import java.time.LocalDate;
 import java.util.List;
+import lombok.extern.slf4j.Slf4j;
 import org.assertj.core.api.Assertions;
 import org.junit.jupiter.api.DisplayName;
 import org.junit.jupiter.api.DisplayNameGeneration;
@@ -17,59 +24,88 @@ import org.springframework.test.context.ActiveProfiles;
 import org.springframework.test.context.jdbc.Sql;
 
 @DataJpaTest
-@Import({StudentHomeworkAdapter.class, StudentHomeworkQueryRepository.class, QuerydslTestConfig.class})
+@Import({StudentHomeworkAdapter.class, StudentHomeworkQueryRepository.class,
+    QuerydslTestConfig.class})
 @ActiveProfiles("test")
 @DisplayName("StudentHomeworkAdapterTest 클래스")
 @DisplayNameGeneration(ReplaceUnderscores.class)
+@Slf4j
 class StudentHomeworkAdapterTest {
 
 
   @Autowired
   StudentHomeworkAdapter studentHomeworkAdapter;
 
+  @Autowired
+  StudentHomeworkJpaRepository studentHomeworkJpaRepository;
+
+  @Sql("/data/student-homework.sql")
+  @Nested
+  class saveAllStudentHomeworks_메서드는 {
+
+    @Nested
+    class 유효한_StudentHomework_리스트가_주어지면 {
+
+      @Test
+      void 성공적으로_해당_정보를_저장한다() {
+        List<StudentHomework> studentHomeworks = MonkeyUtils.MONKEY.giveMeBuilder(
+                StudentHomework.class)
+            .setNull("id")
+            .set("homework",
+                Homework.builder().id(1L).lesson(Lesson.builder().id(1L).build()).build())
+            .set("student", Student.builder().id(1L).build())
+            .sampleList(10000);
+
+        long startTime = System.currentTimeMillis();
+        studentHomeworkAdapter.saveAllStudentHomeworks(studentHomeworks);
+        long endTime = System.currentTimeMillis();
+
+        log.info(("수행시간: {}"), endTime - startTime);
+      }
+    }
+  }
 
   @Nested
   @Sql("/data/student-homework.sql")
   class findHomeworksOfCalendar_메소드는 {
+
     @Nested
     class 년_월_일이_주어지면 {
 
       @Nested
-      class 수업이_없는_선생님_Id가_주어지면{
+      class 수업이_없는_선생님_Id가_주어지면 {
 
         @Test
         void 빈_리스트를_반환한다() {
-          List<OutHomeworkOfGivenDate> homeworks = studentHomeworkAdapter.findHomeworksOfCalendar(LocalDate.now(), 7L);
+          List<OutHomeworkOfGivenDate> homeworks = studentHomeworkAdapter.findHomeworksOfCalendar(
+              LocalDate.now(), 7L);
           Assertions.assertThat(homeworks).isEmpty();
         }
 
       }
 
       @Nested
-      class 수업이_없는_날짜를_반환하면{
+      class 수업이_없는_날짜를_반환하면 {
 
         @Test
         void 빈_리스트를_반환한다() {
-          List<OutHomeworkOfGivenDate> homeworks = studentHomeworkAdapter.findHomeworksOfCalendar(LocalDate.now().plusDays(2), 7L);
+          List<OutHomeworkOfGivenDate> homeworks = studentHomeworkAdapter.findHomeworksOfCalendar(
+              LocalDate.now().plusDays(2), 7L);
           Assertions.assertThat(homeworks).isEmpty();
         }
-
       }
 
       @Nested
-      class 모든_조건이_유효하면{
+      class 모든_조건이_유효하면 {
 
         @Test
         void 숙제_리스트를_반환한다() {
-          List<OutHomeworkOfGivenDate> homeworks = studentHomeworkAdapter.findHomeworksOfCalendar(LocalDate.now(), 1L);
+          List<OutHomeworkOfGivenDate> homeworks = studentHomeworkAdapter.findHomeworksOfCalendar(
+              LocalDate.now(), 1L);
 
           Assertions.assertThat(homeworks.size()).isEqualTo(4);
         }
-
       }
     }
-
   }
-
-
 }

--- a/src/test/resources/application-test.yaml
+++ b/src/test/resources/application-test.yaml
@@ -7,6 +7,9 @@ spring:
     url: jdbc:tc:mysql:8:///noti
     username: noti
     password: noti
+    hikari:
+      data-source-properties:
+        rewriteBatchedStatements: true
 
   jpa:
     database-platform: org.hibernate.dialect.MySQL8Dialect
@@ -14,8 +17,11 @@ spring:
       ddl-auto: create-drop
     properties:
       hibernate:
+        order_updates: true
+        order_inserts: true
         format_sql: true
         show_sql: true
+
 
 jwt:
   secret: secretKey-test-jwt-for-noti-project-update


### PR DESCRIPTION
숙제 추가 기능을 구현했습니다.

우선 batch insert를 위한 properties 추가가 있어서 submodule 한번 최신화 시켜주시고 연결 버전 바꿔주세요

Fixture Monkey 에서 객체 생성시 validate 어노테이션이 붙어있으면 해당 조건대로 생성할 수 있어서 버전을 업데이트하고 해당 서드파티를 추가했습니다. 

숙제 5개를 추가하려하고 그 수업의 학생이 10명이라 할때 StudentHomework 를 추가해서 저장해야되는데  이 경우에 50개의 insert가 필요합니다. 그래서 batch insert를 구현하게됐는데 ID 생성 전략이 identity 일 경우 auto increment 방식으로 id가 생성되기때문에 jpa의 saveAll 메서드와 batch size를 설정해도 지연쓰기가되지않습니다. 그래서 jdbc로 직접 구현하게 되었습니다. 

알람 저장은 시간 세팅이 0이 아닐 경우 레디스에 숙제 ID와 만료시간을 설정해서 저장하게되는데 이 후 알람 구현을 위해서 이렇게 했습니다.