### PR TITLE
[FEAT] NOTI-67 expire event listener 구현

### DIFF
--- a/src/main/java/com/noti/noti/common/adapter/out/listener/ExpirationListener.java
+++ b/src/main/java/com/noti/noti/common/adapter/out/listener/ExpirationListener.java
@@ -1,0 +1,16 @@
+package com.noti.noti.common.adapter.out.listener;
+
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.redis.connection.Message;
+import org.springframework.data.redis.connection.MessageListener;
+import org.springframework.stereotype.Component;
+
+@Component
+@Slf4j
+public class ExpirationListener implements MessageListener {
+
+  @Override
+  public void onMessage(Message message, byte[] pattern) {
+    log.info("onMessage pattern: {} key : {}, {}, {}", new String(pattern), new String(message.getBody()));
+  }
+}

--- a/src/main/java/com/noti/noti/config/RedisConfig.java
+++ b/src/main/java/com/noti/noti/config/RedisConfig.java
@@ -1,5 +1,6 @@
 package com.noti.noti.config;
 
+import com.noti.noti.common.adapter.out.listener.ExpirationListener;
 import lombok.RequiredArgsConstructor;
 import org.springframework.boot.autoconfigure.data.redis.RedisProperties;
 import org.springframework.context.annotation.Bean;
@@ -8,6 +9,8 @@ import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
 import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
 import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
@@ -16,6 +19,8 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 @EnableRedisRepositories(enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP, keyspaceNotificationsConfigParameter = "")
 public class RedisConfig {
   private final RedisProperties redisProperties;
+  private final String PATTERN = "__keyevent@*__:expired";
+
 
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
@@ -28,5 +33,13 @@ public class RedisConfig {
     redisTemplate.setConnectionFactory(redisConnectionFactory());
     redisTemplate.setDefaultSerializer(new StringRedisSerializer());
     return redisTemplate;
+  }
+
+  @Bean
+  public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory, ExpirationListener expirationListener) {
+    RedisMessageListenerContainer redisMessageListenerContainer = new RedisMessageListenerContainer();
+    redisMessageListenerContainer.setConnectionFactory(redisConnectionFactory);
+    redisMessageListenerContainer.addMessageListener(expirationListener, new PatternTopic(PATTERN));
+    return redisMessageListenerContainer;
   }
 }

--- a/src/test/java/com/noti/noti/common/adapter/out/listener/ExpirationListenerTest.java
+++ b/src/test/java/com/noti/noti/common/adapter/out/listener/ExpirationListenerTest.java
@@ -30,7 +30,6 @@ class ExpirationListenerTest extends RedisTestContainerConfig {
   void test() throws InterruptedException {
     ValueOperations<String, String> stringStringValueOperations = stringRedisTemplate.opsForValue();
     stringStringValueOperations.set(KEY, "1");
-    stringStringValueOperations.set("4242", "1");
     stringRedisTemplate.expireAt(KEY, Timestamp.valueOf(LocalDateTime.now().plusSeconds(1L)));
     Thread.sleep(1100);
   }

--- a/src/test/java/com/noti/noti/common/adapter/out/listener/ExpirationListenerTest.java
+++ b/src/test/java/com/noti/noti/common/adapter/out/listener/ExpirationListenerTest.java
@@ -1,0 +1,37 @@
+package com.noti.noti.common.adapter.out.listener;
+
+import com.noti.noti.common.RedisTestContainerConfig;
+import com.noti.noti.config.RedisTemplateTestConfig;
+import java.sql.Timestamp;
+import java.time.LocalDateTime;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.core.ValueOperations;
+import org.springframework.test.context.ActiveProfiles;
+import org.springframework.test.context.junit.jupiter.SpringExtension;
+
+@Import({RedisTemplateTestConfig.class})
+@ExtendWith(SpringExtension.class)
+@ActiveProfiles("test")
+@DisplayName("ExpirationListenerTest 클래스")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class ExpirationListenerTest extends RedisTestContainerConfig {
+  @Autowired
+  StringRedisTemplate stringRedisTemplate;
+
+  final String KEY = "1";
+  @Test
+  void test() throws InterruptedException {
+    ValueOperations<String, String> stringStringValueOperations = stringRedisTemplate.opsForValue();
+    stringStringValueOperations.set(KEY, "1");
+    stringStringValueOperations.set("4242", "1");
+    stringRedisTemplate.expireAt(KEY, Timestamp.valueOf(LocalDateTime.now().plusSeconds(1L)));
+    Thread.sleep(1100);
+  }
+}

--- a/src/test/java/com/noti/noti/config/RedisTemplateTestConfig.java
+++ b/src/test/java/com/noti/noti/config/RedisTemplateTestConfig.java
@@ -1,19 +1,32 @@
 package com.noti.noti.config;
 
+import com.noti.noti.common.adapter.out.listener.ExpirationListener;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.boot.test.context.TestConfiguration;
 import org.springframework.context.annotation.Bean;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
+import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.data.redis.listener.PatternTopic;
+import org.springframework.data.redis.listener.RedisMessageListenerContainer;
+import org.springframework.data.redis.repository.configuration.EnableRedisRepositories;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @TestConfiguration
+@EnableRedisRepositories(enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP)
 public class RedisTemplateTestConfig {
+
+  private final String PATTERN = "__keyevent@*__:expired";
+  @Value("${spring.redis.host}")
+  private String host;
+  @Value("${spring.redis.port}")
+  private int port;
 
   @Bean
   public RedisConnectionFactory redisConnectionFactory() {
-    return new LettuceConnectionFactory();
+    return new LettuceConnectionFactory(host, port);
   }
 
   @Bean
@@ -25,10 +38,20 @@ public class RedisTemplateTestConfig {
   }
 
   @Bean
-  public StringRedisTemplate stringRedisTemplate(){
+  public StringRedisTemplate stringRedisTemplate() {
     StringRedisTemplate stringRedisTemplate = new StringRedisTemplate();
     stringRedisTemplate.setConnectionFactory(redisConnectionFactory());
     stringRedisTemplate.setDefaultSerializer(new StringRedisSerializer());
     return stringRedisTemplate;
+  }
+
+  @Bean
+  public RedisMessageListenerContainer redisMessageListenerContainer(
+      RedisConnectionFactory redisConnectionFactory) {
+    RedisMessageListenerContainer redisMessageListenerContainer = new RedisMessageListenerContainer();
+    redisMessageListenerContainer.setConnectionFactory(redisConnectionFactory);
+    redisMessageListenerContainer.addMessageListener(new ExpirationListener(),
+        new PatternTopic(PATTERN));
+    return redisMessageListenerContainer;
   }
 }


### PR DESCRIPTION
알림 서비스를 위해 알림을 보내야할 시간을 레디스에 저장했었습니다. 시간이 되면 redis key가 만료가 되는데 이때 이벤트를 얻기 위해서 
message listener 를 구현했습니다. onMessage 메서드는 알림을 구현하면서 바뀔 예정입니다.