### PR TITLE
[NOTI 70] 캘린더 빈도 수 관련 조회 동일한 요청 보내도록 수정

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,3 +40,4 @@ out/
 src/main/resources/**.yaml
 
 .jqwik-database
+/src/main/resources/import.sql

--- a/src/main/java/com/noti/noti/homework/adapter/in/web/dto/response/FilteredHomeworkDto.java
+++ b/src/main/java/com/noti/noti/homework/adapter/in/web/dto/response/FilteredHomeworkDto.java
@@ -11,11 +11,11 @@ public class FilteredHomeworkDto {
   @Schema(description = "날짜", example = "2023-02-01")
   private LocalDate date;
   @Schema(description = "해당 날짜에 대한 숙제 수", example = "4")
-  private int homeworkCnt;
+  private int count;
 
   public FilteredHomeworkDto(InFilteredHomeworkFrequency in) {
     this.date = in.getDate();
-    this.homeworkCnt = in.getHomeworksCnt();
+    this.count = in.getHomeworksCnt();
   }
 
 

--- a/src/main/java/com/noti/noti/homework/adapter/out/persistence/HomeworkQueryRepository.java
+++ b/src/main/java/com/noti/noti/homework/adapter/out/persistence/HomeworkQueryRepository.java
@@ -5,6 +5,10 @@ import static com.noti.noti.lesson.adapter.out.persistence.jpa.model.QLessonJpaE
 import static com.noti.noti.studenthomework.adapter.out.persistence.jpa.model.QStudentHomeworkJpaEntity.studentHomeworkJpaEntity;
 import static com.querydsl.core.group.GroupBy.groupBy;
 import static com.querydsl.core.group.GroupBy.list;
+import static com.querydsl.core.types.dsl.Expressions.as;
+import static com.querydsl.core.types.dsl.Expressions.booleanOperation;
+import static com.querydsl.core.types.dsl.Expressions.constant;
+import static com.querydsl.core.types.dsl.Expressions.dateTemplate;
 
 import com.noti.noti.homework.application.port.out.OutFilteredHomeworkFrequency;
 import com.noti.noti.homework.application.port.out.OutHomeworkContent;
@@ -16,7 +20,6 @@ import com.querydsl.core.types.Ops;
 import com.querydsl.core.types.Projections;
 import com.querydsl.core.types.dsl.BooleanExpression;
 import com.querydsl.core.types.dsl.DateTimePath;
-import com.querydsl.core.types.dsl.Expressions;
 import com.querydsl.core.types.dsl.NumberPath;
 import com.querydsl.core.types.dsl.StringExpression;
 import com.querydsl.core.types.dsl.StringExpressions;
@@ -70,7 +73,7 @@ public class HomeworkQueryRepository {
 
   private BooleanExpression currentTimeOperation(LocalDateTime now) {
     log.info("now: {}", now);
-    return now != null ? Expressions.booleanOperation(Ops.BETWEEN, Expressions.constant(now),
+    return now != null ? booleanOperation(Ops.BETWEEN, constant(now),
         homeworkJpaEntity.startTime, homeworkJpaEntity.endTime) : null;
   }
 
@@ -89,23 +92,25 @@ public class HomeworkQueryRepository {
   public List<OutFilteredHomeworkFrequency> findFilteredHomeworkFrequency(Long teacherId, Long lessonId, LocalDateTime startDateOfMonth, LocalDateTime endDateOfMonth) {
     return queryFactory
         .select(Projections.constructor(OutFilteredHomeworkFrequency.class,
-            homeworkJpaEntity.startTime.as("date"),
+            as(constant(startDateOfMonth.getYear()), "year"),
+            as(constant(startDateOfMonth.getMonthValue()), "month"),
+            homeworkJpaEntity.startTime.dayOfMonth().as("day"),
             homeworkJpaEntity.id.count().as("homeworkCnt")
         ))
         .from(homeworkJpaEntity)
         .innerJoin(homeworkJpaEntity.lessonJpaEntity, lessonJpaEntity)
         .where(
             eqTeacherId(teacherId),
-            eqLessonIdOfTeacher(lessonId),
+            eqLessonId(lessonId),
             betweenYearMonth(startDateOfMonth, endDateOfMonth)
         )
-        .groupBy(lessonJpaEntity.startTime)
+        .groupBy(homeworkJpaEntity.startTime.dayOfMonth(), homeworkJpaEntity.startTime.yearMonth())
         .fetch();
   }
 
-  private BooleanExpression eqLessonIdOfTeacher(Long lessonId) {
+  private BooleanExpression eqLessonId(Long lessonId) {
     log.info("lesson Id: {} ", lessonId);
-    return lessonId != null ? lessonJpaEntity.teacherJpaEntity.id.eq(lessonId) : null;
+    return lessonId != null ? lessonJpaEntity.id.eq(lessonId) : null;
   }
 
   private BooleanExpression betweenYearMonth(LocalDateTime start, LocalDateTime end) {
@@ -198,7 +203,7 @@ public class HomeworkQueryRepository {
   }
 
   private StringExpression dateFormatExpression(DateTimePath<LocalDateTime> localDateTime, String pattern) {
-    return Expressions.dateTemplate(String.class,
+    return dateTemplate(String.class,
         "function('date_format', {0}, {1})",
         localDateTime, ConstantImpl.create(pattern)).stringValue();
   }

--- a/src/main/java/com/noti/noti/homework/application/port/in/FilteredHomeworkCommand.java
+++ b/src/main/java/com/noti/noti/homework/application/port/in/FilteredHomeworkCommand.java
@@ -1,5 +1,6 @@
 package com.noti.noti.homework.application.port.in;
 
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.format.DateTimeFormatter;
 import lombok.Getter;
@@ -14,31 +15,7 @@ public class FilteredHomeworkCommand {
   public FilteredHomeworkCommand(long teacherId, long lessonId, int year, int month) {
     this.teacherId = teacherId;
     this.lessonId = lessonId;
-    this.date = stringToLocalDateTime(year, month);
-  }
-
-  /**
-   *
-   * @param year
-   * @param month
-   * @return
-   */
-  private LocalDateTime stringToLocalDateTime(int year, int month) {
-
-    StringBuilder stringBuilder = new StringBuilder();
-
-    if (month > 9) {
-      stringBuilder.append(year).append("-").append(month).append("-01 00:00:00.000");
-    } else {
-      stringBuilder.append(year).append("-0").append(month).append("-01 00:00:00.000");
-    }
-
-
-
-//    stringBuilder.append(yearMonth).append("-01 00:00:00.000");
-    DateTimeFormatter formatter = DateTimeFormatter.ofPattern("yyyy-MM-dd HH:mm:ss.SSS");
-
-    return LocalDateTime.parse(stringBuilder, formatter);
+    this.date = LocalDate.of(year, month, 1).atStartOfDay();
   }
 
 }

--- a/src/main/java/com/noti/noti/homework/application/port/out/OutFilteredHomeworkFrequency.java
+++ b/src/main/java/com/noti/noti/homework/application/port/out/OutFilteredHomeworkFrequency.java
@@ -1,16 +1,25 @@
 package com.noti.noti.homework.application.port.out;
 
 import java.time.LocalDate;
+import java.time.LocalDateTime;
+import javax.persistence.criteria.CriteriaBuilder.In;
 import lombok.Getter;
+import lombok.NoArgsConstructor;
 
 @Getter
+@NoArgsConstructor
 public class OutFilteredHomeworkFrequency {
 
   private LocalDate date;
   private int homeworkCnt;
 
-  public OutFilteredHomeworkFrequency(LocalDate date, int homeworkCnt) {
-    this.date = date;
-    this.homeworkCnt = homeworkCnt;
+  public OutFilteredHomeworkFrequency(int year, int month, Integer dayOfMonth, Long homeworkCnt) {
+    this.date = LocalDate.of(year, month, dayOfMonth);
+    this.homeworkCnt = homeworkCnt.intValue();
+  }
+
+  public OutFilteredHomeworkFrequency(LocalDateTime date, Long homeworkCnt) {
+    this.date = date.toLocalDate();
+    this.homeworkCnt = homeworkCnt.intValue();
   }
 }

--- a/src/main/java/com/noti/noti/lesson/adapter/in/web/controller/GetFrequencyOfLessonsController.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/in/web/controller/GetFrequencyOfLessonsController.java
@@ -50,7 +50,15 @@ public class GetFrequencyOfLessonsController {
       @AuthenticationPrincipal UserDetails userDetails) {
 
     long teacherId = Long.parseLong(userDetails.getUsername());
-    String yearMonth = new StringBuilder().append(year).append("-").append(month).toString();
+    String yearMonth;
+
+    StringBuilder sb = new StringBuilder();
+    if (month < 10) {
+      yearMonth = sb.append(year).append("-0").append(month).toString();
+      System.out.println("yearMonth = " + yearMonth);
+    } else {
+      yearMonth = sb.append(year).append("-").append(month).toString();
+    }
 
     List<DateFrequencyOfLessons> frequencyOfLessons = getFrequencyOfLessonsQuery.findFrequencyOfLessons(yearMonth, teacherId);
     List<FrequencyOfLessonsDto> frequencyOfLessonsDto = new ArrayList<>();

--- a/src/main/java/com/noti/noti/lesson/adapter/in/web/dto/response/FrequencyOfLessonsDto.java
+++ b/src/main/java/com/noti/noti/lesson/adapter/in/web/dto/response/FrequencyOfLessonsDto.java
@@ -10,12 +10,12 @@ import lombok.NoArgsConstructor;
 public class FrequencyOfLessonsDto {
 
   @Schema(description = "숙업이 있는 날짜", example = "2023-01-27")
-  private LocalDate dateOfLesson;
+  private LocalDate date;
   @Schema(description = "dateOfLesson 날짜에 해당하는 수업 수", example = "3")
-  private Long frequencyOfLesson;
+  private Long count;
 
   public FrequencyOfLessonsDto(LocalDate dateOfLesson, Long frequencyOfLesson) {
-    this.dateOfLesson = dateOfLesson;
-    this.frequencyOfLesson = frequencyOfLesson;
+    this.date = dateOfLesson;
+    this.count = frequencyOfLesson;
   }
 }

--- a/src/test/java/com/noti/noti/homework/adapter/in/web/GetFilteredHomeworkControllerTest.java
+++ b/src/test/java/com/noti/noti/homework/adapter/in/web/GetFilteredHomeworkControllerTest.java
@@ -2,7 +2,6 @@ package com.noti.noti.homework.adapter.in.web;
 
 import static org.mockito.ArgumentMatchers.any;
 
-import com.noti.noti.common.MonkeyUtils;
 import com.noti.noti.common.WithAuthUser;
 import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
 import com.noti.noti.config.JacksonConfiguration;
@@ -47,9 +46,9 @@ class GetFilteredHomeworkControllerTest {
 
 
   List<InFilteredHomeworkFrequency> createInFilteredHomeworkFrequency() {
-    OutFilteredHomeworkFrequency out1 = new OutFilteredHomeworkFrequency(LocalDate.of(2022, 2, 3), 2);
-    OutFilteredHomeworkFrequency out2 = new OutFilteredHomeworkFrequency(LocalDate.of(2022, 2, 7), 3);
-    OutFilteredHomeworkFrequency out3 = new OutFilteredHomeworkFrequency(LocalDate.of(2022, 2, 10), 4);
+    OutFilteredHomeworkFrequency out1 = new OutFilteredHomeworkFrequency(LocalDate.of(2022, 2, 3).atStartOfDay(), 2L);
+    OutFilteredHomeworkFrequency out2 = new OutFilteredHomeworkFrequency(LocalDate.of(2022, 2, 7).atStartOfDay(), 3L);
+    OutFilteredHomeworkFrequency out3 = new OutFilteredHomeworkFrequency(LocalDate.of(2022, 2, 10).atStartOfDay(), 4L);
 
 
     InFilteredHomeworkFrequency in1 = new InFilteredHomeworkFrequency(out1);
@@ -74,9 +73,9 @@ class GetFilteredHomeworkControllerTest {
       void 선생님이_수업을_생성했다면_해당리스트_반환() throws Exception {
         Mockito.when(getFilteredHomeworkQuery.getFilteredHomeworks(any(FilteredHomeworkCommand.class)))
             .thenReturn(createInFilteredHomeworkFrequency());
-        MultiValueMap<String, String> info = createParams(2022, 2, 1L);
+        MultiValueMap<String, String> info = createParams(2022, 2, "1");
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/teacher/calendar/filtered").params(info))
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/teacher/calendar").params(info))
             .andExpect(MockMvcResultMatchers.jsonPath("$.size()").value(3))
             .andExpect(MockMvcResultMatchers.status().isOk());
       }
@@ -86,9 +85,9 @@ class GetFilteredHomeworkControllerTest {
       void 선생님이_생성한_수업이_없다면_빈리스트_반환() throws Exception {
         Mockito.when(getFilteredHomeworkQuery.getFilteredHomeworks(any(FilteredHomeworkCommand.class)))
             .thenReturn(createEmptyInFilteredHomeworkFrequency());
-        MultiValueMap<String, String> info = createParams(2022, 2, 1L);
+        MultiValueMap<String, String> info = createParams(2022, 2, "1");
 
-        mockMvc.perform(MockMvcRequestBuilders.get("/api/teacher/calendar/filtered").params(info))
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/teacher/calendar").params(info))
             .andExpect(MockMvcResultMatchers.status().isOk())
             .andExpect(MockMvcResultMatchers.jsonPath("$.message").value(SuccessResponse.SUCCESS_MESSAGE))
             .andExpect(MockMvcResultMatchers.jsonPath("$.status").value(200))
@@ -97,22 +96,40 @@ class GetFilteredHomeworkControllerTest {
 
     }
 
+    @Nested
+    class filter_값이_all {
+
+      @Test
+      @WithAuthUser(id = "1", role = "TEACHER")
+      void api_calendar_all_리다이렉트() throws Exception {
+        Mockito.when(getFilteredHomeworkQuery.getFilteredHomeworks(any(FilteredHomeworkCommand.class)))
+            .thenReturn(createInFilteredHomeworkFrequency());
+        MultiValueMap<String, String> info = createParams(2022, 2, "all");
+
+        mockMvc.perform(MockMvcRequestBuilders.get("/api/teacher/calendar").params(info))
+            .andExpect(MockMvcResultMatchers.redirectedUrl("/api/teacher/calendar/all?year=" + info.get("year").get(0)+ "&month=" + info.get("month").get(0)))
+            .andExpect(MockMvcResultMatchers.status().is3xxRedirection());
+      }
+
+    }
+
+
     @Test
     void 유효하지_않는_선생님Id_라면_응답코드_401() throws Exception {
       Mockito.when(getFilteredHomeworkQuery.getFilteredHomeworks(any(FilteredHomeworkCommand.class)))
           .thenReturn(createEmptyInFilteredHomeworkFrequency());
 
-      mockMvc.perform(MockMvcRequestBuilders.get("/api/teacher/calendar/filtered"))
+      mockMvc.perform(MockMvcRequestBuilders.get("/api/teacher/calendar"))
           .andExpect(MockMvcResultMatchers.status().is(401));
     }
 
   }
 
-  private MultiValueMap<String, String> createParams(int year, int month, Long lessonId) {
+  private MultiValueMap<String, String> createParams(int year, int month, String lessonId) {
     MultiValueMap<String, String> info = new LinkedMultiValueMap<>();
     info.add("year", String.valueOf(year));
     info.add("month", String.valueOf(month));
-    info.add("lessonId", String.valueOf(lessonId));
+    info.add("filter", String.valueOf(lessonId));
     return info;
   }
 

--- a/src/test/java/com/noti/noti/homework/adapter/out/persistence/HomeworkQueryRepositoryTest.java
+++ b/src/test/java/com/noti/noti/homework/adapter/out/persistence/HomeworkQueryRepositoryTest.java
@@ -3,7 +3,10 @@ package com.noti.noti.homework.adapter.out.persistence;
 import static org.assertj.core.api.Assertions.assertThat;
 
 import com.noti.noti.config.QuerydslTestConfig;
+import com.noti.noti.homework.application.port.out.OutFilteredHomeworkFrequency;
 import com.noti.noti.homework.application.port.out.SearchedHomework;
+import java.time.LocalDate;
+import java.time.LocalDateTime;
 import java.util.List;
 import lombok.extern.slf4j.Slf4j;
 import org.junit.jupiter.api.DisplayName;
@@ -175,4 +178,21 @@ class HomeworkQueryRepositoryTest {
     }
   }
 
+  @Nested
+  @Sql("/data/homework.sql")
+  class findFilteredHomeworkFrequency_메소드는 {
+
+    @Test
+    void 주어진_수업에_대한_숙제_빈도를_반환한다() {
+
+      LocalDateTime startOfMonth = LocalDate.now().atStartOfDay();
+      LocalDateTime endOfMonth = LocalDate.now().atStartOfDay().plusMonths(1).minusSeconds(1);
+      List<OutFilteredHomeworkFrequency> filteredHomeworkFrequency = homeworkQueryRepository.findFilteredHomeworkFrequency(
+          1L, 1L, startOfMonth, endOfMonth);
+
+      assertThat(filteredHomeworkFrequency.size()).isEqualTo(3);
+
+    }
+
+ }
 }

--- a/src/test/java/com/noti/noti/homework/application/service/GetFilteredHomeworkServiceTest.java
+++ b/src/test/java/com/noti/noti/homework/application/service/GetFilteredHomeworkServiceTest.java
@@ -72,6 +72,24 @@ class GetFilteredHomeworkServiceTest {
       assertThat(in.get(1)).isInstanceOf(InFilteredHomeworkFrequency.class);
     }
 
+    @DisplayName("모든 조건을 충족할 때 OutFilteredHomeworkFrequency 와 같은 내용 반환")
+    @Test
+    void return_same_content_OutFilteredHomeworkFrequency() {
+
+      // 어댑터로 넘어가는 포트 mock
+      when(findFilteredHomeworkPort.findFilteredHomeworks(any(), anyLong(), anyLong()))
+          .thenReturn(createOutList());
+
+      List<InFilteredHomeworkFrequency> in = getFilteredHomeworkService.getFilteredHomeworks(
+          validCommand());
+
+      for (int i = 0; i < 3; i++) {
+        assertThat(in.get(i).getDate()).isEqualTo(createOutList().get(i).getDate());
+        assertThat(in.get(i).getHomeworksCnt()).isEqualTo(createOutList().get(i).getHomeworkCnt());
+      }
+
+    }
+
     @DisplayName("선생님이 만든 수업이 없으면 InFilteredHomeworkFrequency 타입의 빈 리스트 반환")
     @Test
     void notMeetAllCond() {

--- a/src/test/java/com/noti/noti/homework/application/service/GetFilteredHomeworkServiceTest.java
+++ b/src/test/java/com/noti/noti/homework/application/service/GetFilteredHomeworkServiceTest.java
@@ -37,11 +37,12 @@ class GetFilteredHomeworkServiceTest {
 
   List<OutFilteredHomeworkFrequency> createOutList() {
     OutFilteredHomeworkFrequency out1 = new OutFilteredHomeworkFrequency(
-        LocalDate.of(2023, 2, 25), 2);
+
+        LocalDate.of(2023, 2, 25).atStartOfDay(), 2L);
     OutFilteredHomeworkFrequency out2 = new OutFilteredHomeworkFrequency(
-        LocalDate.of(2023, 2, 26), 1);
+        LocalDate.of(2023, 2, 26).atStartOfDay(), 1L);
     OutFilteredHomeworkFrequency out3 = new OutFilteredHomeworkFrequency(
-        LocalDate.of(2023, 2, 27), 4);
+        LocalDate.of(2023, 2, 27).atStartOfDay(), 4L);
     return List.of(out1, out2, out3);
   }
 

--- a/src/test/resources/data/homework.sql
+++ b/src/test/resources/data/homework.sql
@@ -1,99 +1,49 @@
-insert into teacher
-values (1, 'teacher@gmail.com', 'teacher', '', '', 'TEACHER', 'KAKAO');
-insert into teacher
-values (2, 'teacher2@gmail.com', 'teacher2', '', '', 'TEACHER', 'KAKAO');
-insert into teacher
-values (3, 'teacher3@gmail.com', 'teacher3', '', '', 'TEACHER', 'KAKAO');
+insert into teacher values (1, 'teacher@gmail.com', 'teacher', '', '', 'TEACHER', 'KAKAO');
+insert into teacher values (2, 'teacher2@gmail.com', 'teacher2', '', '', 'TEACHER', 'KAKAO');
+insert into teacher values (3, 'teacher3@gmail.com', 'teacher3', '', '', 'TEACHER', 'KAKAO');
 
-insert into student
-values (1, now(), now(), 'stu@gmail.com', 'student', 'image', 1234);
-insert into student
-values (2, now(), now(), 'stu2@gmail.com', 'student2', 'image2', 12345);
-insert into student
-values (3, now(), now(), 'stu3@gmail.com', 'student3', 'image3', 12341);
-insert into student
-values (4, now(), now(), 'stu4@gmail.com', 'student4', 'image4', 12342);
+insert into student values (1, now(), now(), 'stu@gmail.com', 'student', 'image', 1234);
+insert into student values (2, now(), now(), 'stu2@gmail.com', 'student2', 'image2', 12345);
+insert into student values (3, now(), now(), 'stu3@gmail.com', 'student3', 'image3', 12341);
+insert into student values (4, now(), now(), 'stu4@gmail.com', 'student4', 'image4', 12342);
 
-insert into lesson
-values (1, now(), now(), 'MONDAY,TUESDAY,WEDNESDAY,THURSDAY', '13:00:00', '수학', '12:00:00', 1);
-insert into lesson
-values (2, now(), now(), 'MONDAY,FRIDAY, SATURDAY', '17:00:00', '수학2', '15:00:00', 1);
-insert into lesson
-values (3, now(), now(), 'FRIDAY,THURSDAY', '15:00:00', '수학3', '13:00:00', 1);
-insert into lesson
-values (4, now(), now(), 'FRIDAY', '10:00:00', '과학', '09:00:00', 2);
-insert into lesson
-values (5, now(), now(), 'FRIDAY', '12:00:00', '과학2', '11:00:00', 2);
+insert into lesson values (1, now(), now(), 'MONDAY,TUESDAY,WEDNESDAY,THURSDAY', '13:00:00', '수학', '12:00:00', 1);
+insert into lesson values (2, now(), now(), 'MONDAY,FRIDAY, SATURDAY', '17:00:00', '수학2', '15:00:00', 1);
+insert into lesson values (3, now(), now(), 'FRIDAY,THURSDAY', '15:00:00', '수학3', '13:00:00', 1);
+insert into lesson values (4, now(), now(), 'FRIDAY', '10:00:00', '과학', '09:00:00', 2);
+insert into lesson values (5, now(), now(), 'FRIDAY', '12:00:00', '과학2', '11:00:00', 2);
 
-insert into book (book_id, created_at, modified_at, title, teacher_id)
-values (1, now(), now(), '수학의 정석',1);
-insert into book (book_id, created_at, modified_at, title, teacher_id)
-values (2, now(), now(), '수학의 정석2',1);
-insert into book (book_id, created_at, modified_at, title, teacher_id)
-values (3, now(), now(), '물리1',2);
-insert into book (book_id, created_at, modified_at, title, teacher_id)
-values (4, now(), now(), '물리2',2);
+insert into book (book_id, created_at, modified_at, title, teacher_id) values (1, now(), now(), '수학의 정석',1);
+insert into book (book_id, created_at, modified_at, title, teacher_id) values (2, now(), now(), '수학의 정석2',1);
+insert into book (book_id, created_at, modified_at, title, teacher_id) values (3, now(), now(), '물리1',2);
+insert into book (book_id, created_at, modified_at, title, teacher_id) values (4, now(), now(), '물리2',2);
 
-insert into lesson_book (lesson_book_id, created_at, modified_at, book_id, lesson_id)
-values (1, now(), now(), 1, 1);
-insert into lesson_book (lesson_book_id, created_at, modified_at, book_id, lesson_id)
-values (2, now(), now(), 2, 2);
-insert into lesson_book (lesson_book_id, created_at, modified_at, book_id, lesson_id)
-values (3, now(), now(), 1, 3);
-insert into lesson_book (lesson_book_id, created_at, modified_at, book_id, lesson_id)
-values (4, now(), now(), 3, 4);
-insert into lesson_book (lesson_book_id, created_at, modified_at, book_id, lesson_id)
-values (5, now(), now(), 4, 5);
+insert into lesson_book (lesson_book_id, created_at, modified_at, book_id, lesson_id) values (1, now(), now(), 1, 1);
+insert into lesson_book (lesson_book_id, created_at, modified_at, book_id, lesson_id) values (2, now(), now(), 2, 2);
+insert into lesson_book (lesson_book_id, created_at, modified_at, book_id, lesson_id) values (3, now(), now(), 1, 3);
+insert into lesson_book (lesson_book_id, created_at, modified_at, book_id, lesson_id) values (4, now(), now(), 3, 4);
+insert into lesson_book (lesson_book_id, created_at, modified_at, book_id, lesson_id) values (5, now(), now(), 4, 5);
 
-insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name,
-                      start_time, lesson_id)
-values (1, now(), now(), 'p 0 ~ 10', now() + INTERVAL 1 DAY, '수학 정석1', now(), 1);
-insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name,
-                      start_time, lesson_id)
-values (2, now(), now(), 'p 100 ~ 110', now(), '수학 정석1', now(), 1);
-insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name,
-                      start_time, lesson_id)
-values (3, now(), now(), 'p 0 ~ 10', now() + INTERVAL 1 DAY, '수학 정석2', now(), 2);
-
-insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name,
-                      start_time, lesson_id)
-values (4, now(), now(), 'p 100 ~ 110', now() + INTERVAL 1 DAY, '수학 정석2', now(), 2);
-insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name,
-                      start_time, lesson_id)
-values (5, now(), now(), 'p 0 ~ 10', now(), '물리 숙제', now(), 4);
-insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name,
-                      start_time, lesson_id)
-values (6, now(), now(), 'p 0 ~ 10', now() + INTERVAL 1 DAY, '물리2 숙제', now(), 5);
+insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name, start_time, lesson_id) values (1, now(), now(), 'p 0 ~ 10', now() + INTERVAL 1 DAY, '수학 정석1', now() + INTERVAL 1 DAY, 1);
+insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name, start_time, lesson_id) values (2, now(), now(), 'p 100 ~ 110', now(), '수학 정석1', now() + INTERVAL 1 HOUR, 1);
+insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name, start_time, lesson_id) values (7, now(), now(), 'p 100 ~ 110', now(), '수학 정석1', now() + INTERVAL 1 MINUTE, 1);
+insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name, start_time, lesson_id) values (8, now(), now(), 'p 100 ~ 110', now(), '수학 정석1', now(), 1);
+insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name, start_time, lesson_id) values (9, now(), now(), 'p 0 ~ 10', now() + INTERVAL 1 DAY, '수학 정석1', now() + INTERVAL 1 DAY, 1);
+insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name, start_time, lesson_id) values (10, now(), now(), 'p 0 ~ 10', now() + INTERVAL 4 DAY, '수학 정석1', now() + INTERVAL 4 DAY, 1);
 
 
-insert into student_homework (student_homework_id, created_at, modified_at, homework_status,
-                              homework_id, student_id)
-values (1, now(), now(), false, 3, 1);
 
-insert into student_homework (student_homework_id, created_at, modified_at, homework_status,
-                              homework_id, student_id)
-values (2, now(), now(), false, 3, 2);
+insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name, start_time, lesson_id) values (3, now(), now(), 'p 0 ~ 10', now() + INTERVAL 1 DAY, '수학 정석2', now(), 2);
+insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name, start_time, lesson_id) values (4, now(), now(), 'p 100 ~ 110', now() + INTERVAL 1 DAY, '수학 정석2', now(), 2);
+insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name, start_time, lesson_id) values (5, now(), now(), 'p 0 ~ 10', now(), '물리 숙제', now(), 4);
+insert into homework (homework_id, created_at, modified_at, content, end_time, homework_name, start_time, lesson_id) values (6, now(), now(), 'p 0 ~ 10', now() + INTERVAL 1 DAY, '물리2 숙제', now(), 5);
 
-insert into student_homework (student_homework_id, created_at, modified_at, homework_status,
-                              homework_id, student_id)
-values (3, now(), now(), false, 3, 3);
 
-insert into student_homework (student_homework_id, created_at, modified_at, homework_status,
-                              homework_id, student_id)
-values (4, now(), now(), false, 3, 4);
-
-insert into student_homework (student_homework_id, created_at, modified_at, homework_status,
-                              homework_id, student_id)
-values (5, now(), now(), false, 4, 1);
-
-insert into student_homework (student_homework_id, created_at, modified_at, homework_status,
-                              homework_id, student_id)
-values (6, now(), now(), false, 4, 2);
-
-insert into student_homework (student_homework_id, created_at, modified_at, homework_status,
-                              homework_id, student_id)
-values (7, now(), now(), false, 4, 3);
-
-insert into student_homework (student_homework_id, created_at, modified_at, homework_status,
-                              homework_id, student_id)
-values (8, now(), now(), false, 4, 4);
+insert into student_homework (student_homework_id, created_at, modified_at, homework_status, homework_id, student_id) values (1, now(), now(), false, 3, 1);
+insert into student_homework (student_homework_id, created_at, modified_at, homework_status, homework_id, student_id) values (2, now(), now(), false, 3, 2);
+insert into student_homework (student_homework_id, created_at, modified_at, homework_status, homework_id, student_id) values (3, now(), now(), false, 3, 3);
+insert into student_homework (student_homework_id, created_at, modified_at, homework_status, homework_id, student_id) values (4, now(), now(), false, 3, 4);
+insert into student_homework (student_homework_id, created_at, modified_at, homework_status, homework_id, student_id) values (5, now(), now(), false, 4, 1);
+insert into student_homework (student_homework_id, created_at, modified_at, homework_status, homework_id, student_id) values (6, now(), now(), false, 4, 2);
+insert into student_homework (student_homework_id, created_at, modified_at, homework_status, homework_id, student_id) values (7, now(), now(), false, 4, 3);
+insert into student_homework (student_homework_id, created_at, modified_at, homework_status, homework_id, student_id) values (8, now(), now(), false, 4, 4);


### PR DESCRIPTION
/api/teacher/calendar?year={year}&month={month}&filter={filter} 주소로 요청하면 아래와 같은 값이 나오도록 함
 - filter가 all이면, 일자별 수업 빈도 수 반환
 - filter가 lessonId 값이면, 수업에 해당하는 일자별 숙제 빈도 수 반환