### PR TITLE
Feature/noti 78 토큰갱신 스케줄링 구현

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -41,3 +41,5 @@ src/main/resources/**.yaml
 
 .jqwik-database
 /src/main/resources/import.sql
+
+serviceAccountKey.json

--- a/build.gradle
+++ b/build.gradle
@@ -88,7 +88,7 @@ processResources.dependsOn('copyPrivate')
 task copyPrivate(type: Copy) {
 	copy {
 		from './noti-config'
-		include "*.yaml"
+		include "*.yaml", "*.json"
 		into 'src/main/resources'
 	}
 }

--- a/build.gradle
+++ b/build.gradle
@@ -56,6 +56,9 @@ dependencies {
 	// redis
 	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
 
+	// firebase admin sdk
+	implementation 'com.google.firebase:firebase-admin:9.2.0'
+
 	// m1 spring cloud gateway
 	implementation 'io.netty:netty-resolver-dns-native-macos:4.1.82.Final:osx-aarch_64'
 

--- a/src/main/java/com/noti/noti/NotiApplication.java
+++ b/src/main/java/com/noti/noti/NotiApplication.java
@@ -3,9 +3,11 @@ package com.noti.noti;
 import org.springframework.boot.SpringApplication;
 import org.springframework.boot.autoconfigure.SpringBootApplication;
 import org.springframework.context.annotation.EnableAspectJAutoProxy;
+import org.springframework.scheduling.annotation.EnableScheduling;
 
 @SpringBootApplication
 @EnableAspectJAutoProxy
+@EnableScheduling
 public class NotiApplication {
 
 	public static void main(String[] args) {

--- a/src/main/java/com/noti/noti/config/FirebaseConfig.java
+++ b/src/main/java/com/noti/noti/config/FirebaseConfig.java
@@ -1,0 +1,29 @@
+package com.noti.noti.config;
+
+import com.google.auth.oauth2.GoogleCredentials;
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import java.io.FileInputStream;
+import java.io.IOException;
+import javax.annotation.PostConstruct;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+public class FirebaseConfig {
+
+  @Value("${firebase.keyPath}")
+  private String keyPath;
+
+  @PostConstruct
+  void init() throws IOException {
+    FileInputStream serviceAccount =
+        new FileInputStream(keyPath);
+
+    FirebaseOptions options = FirebaseOptions.builder()
+        .setCredentials(GoogleCredentials.fromStream(serviceAccount))
+        .build();
+
+    FirebaseApp.initializeApp(options);
+  }
+}

--- a/src/main/java/com/noti/noti/config/RedisConfig.java
+++ b/src/main/java/com/noti/noti/config/RedisConfig.java
@@ -8,6 +8,7 @@ import org.springframework.context.annotation.Configuration;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
+import org.springframework.data.redis.core.RedisKeyValueAdapter.ShadowCopy;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.listener.PatternTopic;
 import org.springframework.data.redis.listener.RedisMessageListenerContainer;
@@ -16,8 +17,9 @@ import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @Configuration
 @RequiredArgsConstructor
-@EnableRedisRepositories(enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP, keyspaceNotificationsConfigParameter = "")
+@EnableRedisRepositories(enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP, keyspaceNotificationsConfigParameter = "", shadowCopy = ShadowCopy.OFF)
 public class RedisConfig {
+
   private final RedisProperties redisProperties;
   private final String PATTERN = "__keyevent@*__:expired";
 
@@ -36,7 +38,8 @@ public class RedisConfig {
   }
 
   @Bean
-  public RedisMessageListenerContainer redisMessageListenerContainer(RedisConnectionFactory redisConnectionFactory, ExpirationListener expirationListener) {
+  public RedisMessageListenerContainer redisMessageListenerContainer(
+      RedisConnectionFactory redisConnectionFactory, ExpirationListener expirationListener) {
     RedisMessageListenerContainer redisMessageListenerContainer = new RedisMessageListenerContainer();
     redisMessageListenerContainer.setConnectionFactory(redisConnectionFactory);
     redisMessageListenerContainer.addMessageListener(expirationListener, new PatternTopic(PATTERN));

--- a/src/main/java/com/noti/noti/notification/adapter/in/web/controller/SaveFcmTokenController.java
+++ b/src/main/java/com/noti/noti/notification/adapter/in/web/controller/SaveFcmTokenController.java
@@ -52,8 +52,7 @@ public class SaveFcmTokenController {
     long userId = Long.parseLong(userDetails.getUsername());
 
     FcmToken fcmToken = saveFcmTokenUsecase.apply(
-        new SaveFcmTokenCommand(saveFcmTokenRequest.getFcmToken(),
-            saveFcmTokenRequest.getDeviceNum(), userId));
+        new SaveFcmTokenCommand(saveFcmTokenRequest.getFcmToken(), userId));
 
     return ResponseEntity.status(HttpStatus.CREATED)
         .body(SuccessResponse.create201SuccessResponse());

--- a/src/main/java/com/noti/noti/notification/adapter/in/web/dto/request/SaveFcmTokenRequest.java
+++ b/src/main/java/com/noti/noti/notification/adapter/in/web/dto/request/SaveFcmTokenRequest.java
@@ -13,8 +13,4 @@ public class SaveFcmTokenRequest {
   @NotBlank
   @Schema(description = "FCM Token", required = true, example = "fcmToken123123")
   private String fcmToken;
-
-  @NotBlank
-  @Schema(description = "디바이스 고유 정보", required = true, example = "123123abc")
-  private String deviceNum;
 }

--- a/src/main/java/com/noti/noti/notification/adapter/out/persistence/FcmAdapter.java
+++ b/src/main/java/com/noti/noti/notification/adapter/out/persistence/FcmAdapter.java
@@ -1,0 +1,33 @@
+package com.noti.noti.notification.adapter.out.persistence;
+
+import com.google.firebase.messaging.FirebaseMessaging;
+import com.google.firebase.messaging.MulticastMessage;
+import com.noti.noti.notification.application.port.out.SendPushPort;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+
+/**
+ * push 메세지를 보내는 FCM adapter 클래스
+ *
+ */
+@Component
+@RequiredArgsConstructor
+public class FcmAdapter implements SendPushPort {
+
+  private final MessageGenerator messageGenerator;
+
+  /**
+   * silent push를 비동기 방식으로 보내는 메서드
+   * @param fcmToken fcm 토큰 목록
+   */
+  @Override
+  public void sendSilentPushForVerifyToken(List<String> fcmToken) {
+    MulticastMessage multicastMessage = messageGenerator.generateMulticastMessageForSilent(
+        fcmToken);
+
+    FirebaseMessaging.getInstance().sendEachForMulticastAsync(multicastMessage);
+  }
+
+}

--- a/src/main/java/com/noti/noti/notification/adapter/out/persistence/FcmTokenMapper.java
+++ b/src/main/java/com/noti/noti/notification/adapter/out/persistence/FcmTokenMapper.java
@@ -21,7 +21,6 @@ public class FcmTokenMapper {
   public FcmToken mapToDomainEntity(FcmTokenRedisEntity fcmTokenRedisEntity) {
     return FcmToken.builder()
         .fcmToken(fcmTokenRedisEntity.getFcmToken())
-        .deviceNum(fcmTokenRedisEntity.getDeviceNum())
         .userId(fcmTokenRedisEntity.getUserId())
         .build();
   }
@@ -35,7 +34,6 @@ public class FcmTokenMapper {
   public FcmTokenRedisEntity mapToRedisEntity(FcmToken fcmToken) {
     return FcmTokenRedisEntity.builder()
         .fcmToken(fcmToken.getFcmToken())
-        .deviceNum(fcmToken.getDeviceNum())
         .userId(fcmToken.getUserId())
         .build();
   }

--- a/src/main/java/com/noti/noti/notification/adapter/out/persistence/FcmTokenPersistenceAdapter.java
+++ b/src/main/java/com/noti/noti/notification/adapter/out/persistence/FcmTokenPersistenceAdapter.java
@@ -1,23 +1,52 @@
 package com.noti.noti.notification.adapter.out.persistence;
 
 import com.noti.noti.notification.adapter.out.persistence.model.FcmTokenRedisEntity;
+import com.noti.noti.notification.application.port.out.FindFcmTokenPort;
 import com.noti.noti.notification.application.port.out.SaveFcmTokenPort;
 import com.noti.noti.notification.domain.model.FcmToken;
+import java.util.ArrayList;
+import java.util.List;
 import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.Cursor;
+import org.springframework.data.redis.core.ScanOptions;
+import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.stereotype.Repository;
 
 
 @RequiredArgsConstructor
 @Repository
-public class FcmTokenPersistenceAdapter implements SaveFcmTokenPort {
+public class FcmTokenPersistenceAdapter implements SaveFcmTokenPort, FindFcmTokenPort {
 
   private final FcmTokenMapper fcmTokenMapper;
   private final FcmTokenRedisRepository fcmTokenRedisRepository;
+  private final StringRedisTemplate redisTemplate;
+  private static final String FCM_TOKEN_KEY_SET_PATTERN = "fcmToken";
+
 
   @Override
   public FcmToken saveFcmToken(FcmToken fcmToken) {
     FcmTokenRedisEntity savedFcmTokenRedisEntity = fcmTokenRedisRepository.save(
         fcmTokenMapper.mapToRedisEntity(fcmToken));
     return fcmTokenMapper.mapToDomainEntity(savedFcmTokenRedisEntity);
+  }
+
+  /**
+   * redis에 저장되어있는 모든 fcmToken의 key를 조회하는 메서드 findAll() 대신 scan을 사용
+   *
+   * @return 키의 목록을 반환
+   */
+  @Override
+  public List<String> findAllFcmTokenKey() {
+    // 10개의 단위로 키의 목록을 조회
+    ScanOptions scanOptions = ScanOptions.scanOptions().count(10).build();
+    Cursor<String> cursor = redisTemplate.opsForSet().scan(FCM_TOKEN_KEY_SET_PATTERN, scanOptions);
+
+    ArrayList<String> fcmTokenKeys = new ArrayList<>();
+
+    while (cursor.hasNext()) {
+      fcmTokenKeys.add(cursor.next());
+    }
+
+    return fcmTokenKeys;
   }
 }

--- a/src/main/java/com/noti/noti/notification/adapter/out/persistence/MessageGenerator.java
+++ b/src/main/java/com/noti/noti/notification/adapter/out/persistence/MessageGenerator.java
@@ -5,6 +5,7 @@ import static com.noti.noti.notification.adapter.out.persistence.MessageHeader.*
 import com.google.firebase.messaging.ApnsConfig;
 import com.google.firebase.messaging.Aps;
 import com.google.firebase.messaging.MulticastMessage;
+import com.google.firebase.messaging.Notification;
 import java.util.List;
 import org.springframework.stereotype.Component;
 
@@ -23,7 +24,17 @@ public class MessageGenerator {
   public MulticastMessage generateMulticastMessageForSilent(List<String> fcmTokens) {
     return MulticastMessage.builder().addAllTokens(fcmTokens)
         .setApnsConfig(generateApnsConfigForSilent())
+        .setNotification(generateNotificationForSilent())
         .build();
+  }
+
+  /**
+   * silent message Notification
+   *
+   * @return Notification for silent push
+   */
+  private Notification generateNotificationForSilent(){
+    return Notification.builder().setTitle("updateFcmToken").build();
   }
 
   /**
@@ -33,9 +44,8 @@ public class MessageGenerator {
    */
   private ApnsConfig generateApnsConfigForSilent() {
     return ApnsConfig.builder()
-        .setAps(Aps.builder().setContentAvailable(true).setCategory("update-fcmToken").build())
-        .putHeader(
-            APNS_PUSH_TYPE.getHeader(), "background")
+        .setAps(Aps.builder().setContentAvailable(true).build())
+        .putHeader(APNS_PUSH_TYPE.getHeader(), "background")
         .putHeader(APNS_PRIORITY.getHeader(), "5").build();
   }
 }

--- a/src/main/java/com/noti/noti/notification/adapter/out/persistence/MessageGenerator.java
+++ b/src/main/java/com/noti/noti/notification/adapter/out/persistence/MessageGenerator.java
@@ -1,0 +1,41 @@
+package com.noti.noti.notification.adapter.out.persistence;
+
+import static com.noti.noti.notification.adapter.out.persistence.MessageHeader.*;
+
+import com.google.firebase.messaging.ApnsConfig;
+import com.google.firebase.messaging.Aps;
+import com.google.firebase.messaging.MulticastMessage;
+import java.util.List;
+import org.springframework.stereotype.Component;
+
+/**
+ * fcm에 보낼 Message를 생성하는 클래스
+ */
+@Component
+public class MessageGenerator {
+
+  /**
+   * silent message를 생성하는 메서드
+   *
+   * @param fcmTokens 메세지를 보낼 타겟 tokens
+   * @return 보내는 토큰들이 담겨있는 MulticastMessage
+   */
+  public MulticastMessage generateMulticastMessageForSilent(List<String> fcmTokens) {
+    return MulticastMessage.builder().addAllTokens(fcmTokens)
+        .setApnsConfig(generateApnsConfigForSilent())
+        .build();
+  }
+
+  /**
+   * silent message를 위한 apns config 생성 메서드
+   *
+   * @return silent push apns config
+   */
+  private ApnsConfig generateApnsConfigForSilent() {
+    return ApnsConfig.builder()
+        .setAps(Aps.builder().setContentAvailable(true).setCategory("update-fcmToken").build())
+        .putHeader(
+            APNS_PUSH_TYPE.getHeader(), "background")
+        .putHeader(APNS_PRIORITY.getHeader(), "5").build();
+  }
+}

--- a/src/main/java/com/noti/noti/notification/adapter/out/persistence/MessageHeader.java
+++ b/src/main/java/com/noti/noti/notification/adapter/out/persistence/MessageHeader.java
@@ -1,0 +1,14 @@
+package com.noti.noti.notification.adapter.out.persistence;
+
+import lombok.Getter;
+
+@Getter
+public enum MessageHeader {
+  APNS_PUSH_TYPE("apns-push-type"),
+  APNS_PRIORITY("apns-priority");
+  private String header;
+
+  MessageHeader(String header) {
+    this.header = header;
+  }
+}

--- a/src/main/java/com/noti/noti/notification/adapter/out/persistence/model/FcmTokenRedisEntity.java
+++ b/src/main/java/com/noti/noti/notification/adapter/out/persistence/model/FcmTokenRedisEntity.java
@@ -13,22 +13,17 @@ import org.springframework.data.redis.core.index.Indexed;
  * deviceNum은 디바이스 고유 번호로 유니크하기 때문에 id로 사용하고,
  * 문서의 요구사항에 따라 2개월의 만료기간을 설정했습니다.
  */
-@RedisHash(timeToLive = 60 * 60 * 24 * 60)
+@RedisHash(value = "fcmToken", timeToLive = 60 * 60 * 24 * 60)
 @Getter
 @NoArgsConstructor(access = AccessLevel.PROTECTED)
 public class FcmTokenRedisEntity {
-
   @Id
-  private String deviceNum;
-
+  private String fcmToken;
   @Indexed
   private Long userId;
 
-  private String fcmToken;
-
   @Builder
-  public FcmTokenRedisEntity(String deviceNum, Long userId, String fcmToken) {
-    this.deviceNum = deviceNum;
+  public FcmTokenRedisEntity(Long userId, String fcmToken) {
     this.userId = userId;
     this.fcmToken = fcmToken;
   }

--- a/src/main/java/com/noti/noti/notification/application/port/in/SaveFcmTokenCommand.java
+++ b/src/main/java/com/noti/noti/notification/application/port/in/SaveFcmTokenCommand.java
@@ -8,12 +8,10 @@ import lombok.NoArgsConstructor;
 public class SaveFcmTokenCommand {
 
   private String fcmToken;
-  private String deviceNum;
   private Long userId;
 
-  public SaveFcmTokenCommand(String fcmToken, String deviceNum, Long userId) {
+  public SaveFcmTokenCommand(String fcmToken, Long userId) {
     this.fcmToken = fcmToken;
-    this.deviceNum = deviceNum;
     this.userId = userId;
   }
 }

--- a/src/main/java/com/noti/noti/notification/application/port/out/FindFcmTokenPort.java
+++ b/src/main/java/com/noti/noti/notification/application/port/out/FindFcmTokenPort.java
@@ -1,0 +1,8 @@
+package com.noti.noti.notification.application.port.out;
+
+import java.util.List;
+
+public interface FindFcmTokenPort {
+
+  List<String> findAllFcmTokenKey();
+}

--- a/src/main/java/com/noti/noti/notification/application/port/out/SendPushPort.java
+++ b/src/main/java/com/noti/noti/notification/application/port/out/SendPushPort.java
@@ -1,0 +1,7 @@
+package com.noti.noti.notification.application.port.out;
+
+import java.util.List;
+
+public interface SendPushPort {
+  void sendSilentPushForVerifyToken(List<String>fcmToken);
+}

--- a/src/main/java/com/noti/noti/notification/application/service/SaveFcmTokenService.java
+++ b/src/main/java/com/noti/noti/notification/application/service/SaveFcmTokenService.java
@@ -18,7 +18,6 @@ public class SaveFcmTokenService implements SaveFcmTokenUsecase {
     FcmToken fcmToken = FcmToken.builder()
         .fcmToken(saveFcmTokenCommand.getFcmToken())
         .userId(saveFcmTokenCommand.getUserId())
-        .deviceNum(saveFcmTokenCommand.getDeviceNum())
         .build();
 
     FcmToken savedFcmToken = saveFcmTokenPort.saveFcmToken(fcmToken);

--- a/src/main/java/com/noti/noti/notification/domain/model/FcmToken.java
+++ b/src/main/java/com/noti/noti/notification/domain/model/FcmToken.java
@@ -8,15 +8,11 @@ import lombok.NoArgsConstructor;
 @NoArgsConstructor
 public class FcmToken {
 
-  private String deviceNum;
-
   private Long userId;
-
   private String fcmToken;
 
   @Builder
-  public FcmToken(String deviceNum, Long userId, String fcmToken) {
-    this.deviceNum = deviceNum;
+  public FcmToken(Long userId, String fcmToken) {
     this.userId = userId;
     this.fcmToken = fcmToken;
   }

--- a/src/main/java/com/noti/noti/schedule/UpdateFcmTokenSchedule.java
+++ b/src/main/java/com/noti/noti/schedule/UpdateFcmTokenSchedule.java
@@ -1,0 +1,56 @@
+package com.noti.noti.schedule;
+
+import com.google.common.collect.Lists;
+import com.noti.noti.notification.application.port.out.FindFcmTokenPort;
+import com.noti.noti.notification.application.port.out.SendPushPort;
+import java.util.List;
+import lombok.RequiredArgsConstructor;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+@Component
+@RequiredArgsConstructor
+public class UpdateFcmTokenSchedule {
+
+  private final FindFcmTokenPort findFcmTokenPort;
+  private final SendPushPort sendPushPort;
+
+  /**
+   *  매달 1일 0시 0분 0초에 실행
+   *  fcmToken들의 유효성을 체크하기 위한 스케쥴링
+   */
+  @Scheduled(cron = "0 0 0 1 * *")
+  public void updateFcmToken(){
+    List<String> fcmTokenKeys = findFcmTokenPort.findAllFcmTokenKey();
+
+    if (canSendPush(fcmTokenKeys)) {
+      sendSilentMessageForVerifyToken(partitionKeys(fcmTokenKeys));
+    }
+  }
+
+  /**
+   * key들의 개수를 확인해 push를 보낼 수 있는지 판단하는 메서드
+   * @param fcmTokenKeys
+   * @return
+   */
+  private boolean canSendPush(List<String> fcmTokenKeys) {
+    return fcmTokenKeys.size() > 0 ? true : false;
+  }
+
+  /**
+   * 요청 한번 당 500개의 메세지를 요청 할 수 있어 key 목록을 500개씩 나누는 메서드
+   * @param fcmTokenKeys
+   * @return 분리된 key들의 리스트
+   */
+  private List<List<String>> partitionKeys(List<String> fcmTokenKeys) {
+    return Lists.partition(fcmTokenKeys, 500);
+  }
+
+  /**
+   * slient push를 보내는 메서드
+   * @param partitionKeys
+   */
+  private void sendSilentMessageForVerifyToken(List<List<String>> partitionKeys) {
+    partitionKeys.forEach(sendPushPort::sendSilentPushForVerifyToken);
+  }
+}

--- a/src/test/java/com/noti/noti/common/MockGoogleCredentials.java
+++ b/src/test/java/com/noti/noti/common/MockGoogleCredentials.java
@@ -1,0 +1,31 @@
+package com.noti.noti.common;
+
+import com.google.auth.oauth2.AccessToken;
+import com.google.auth.oauth2.GoogleCredentials;
+import java.io.IOException;
+import java.util.Date;
+import java.util.concurrent.TimeUnit;
+
+public class MockGoogleCredentials extends GoogleCredentials {
+
+  private String tokenValue;
+  private long expiryTime;
+
+  public MockGoogleCredentials() {
+    this(null);
+  }
+
+  public MockGoogleCredentials(String tokenValue) {
+    this(tokenValue, System.currentTimeMillis() + TimeUnit.HOURS.toMillis(1));
+  }
+
+  public MockGoogleCredentials(String tokenValue, long expiryTime) {
+    this.tokenValue = tokenValue;
+    this.expiryTime = expiryTime;
+  }
+
+  @Override
+  public AccessToken refreshAccessToken() throws IOException {
+    return new AccessToken(tokenValue, new Date(expiryTime));
+  }
+}

--- a/src/test/java/com/noti/noti/config/RedisTemplateTestConfig.java
+++ b/src/test/java/com/noti/noti/config/RedisTemplateTestConfig.java
@@ -7,6 +7,7 @@ import org.springframework.context.annotation.Bean;
 import org.springframework.data.redis.connection.RedisConnectionFactory;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisKeyValueAdapter.EnableKeyspaceEvents;
+import org.springframework.data.redis.core.RedisKeyValueAdapter.ShadowCopy;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.core.StringRedisTemplate;
 import org.springframework.data.redis.listener.PatternTopic;
@@ -15,7 +16,7 @@ import org.springframework.data.redis.repository.configuration.EnableRedisReposi
 import org.springframework.data.redis.serializer.StringRedisSerializer;
 
 @TestConfiguration
-@EnableRedisRepositories(enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP)
+@EnableRedisRepositories(enableKeyspaceEvents = EnableKeyspaceEvents.ON_STARTUP, shadowCopy = ShadowCopy.OFF)
 public class RedisTemplateTestConfig {
 
   private final String PATTERN = "__keyevent@*__:expired";

--- a/src/test/java/com/noti/noti/notification/adapter/in/web/controller/SaveFcmTokenControllerTest.java
+++ b/src/test/java/com/noti/noti/notification/adapter/in/web/controller/SaveFcmTokenControllerTest.java
@@ -49,39 +49,12 @@ class SaveFcmTokenControllerTest {
   ObjectMapper objectMapper;
 
   @Nested
-  class 메서드는 {
-
-    @Nested
-    class deviceNum_key가_없는_요청이_주어지면 {
-
-      final String EMPTY_DEVICE_NUM_REQUEST =
-          "{"
-              + "\"fcmToken\": \"fcmToken\""
-              + "}";
-
-      @WithAuthUser(id = "1", role = "ROLE_TEACHER")
-      @Test
-      void 응답코드_400_에러가_발생한다() throws Exception {
-
-        mockMvc.perform(post("/api/notification/tokens")
-                .with(csrf())
-                .contentType(MediaType.APPLICATION_JSON)
-                .content(EMPTY_DEVICE_NUM_REQUEST))
-            .andExpectAll(
-                status().isBadRequest(),
-                result -> assertThat(result.getResolvedException()).isInstanceOf(
-                    MethodArgumentNotValidException.class)
-            );
-      }
-    }
+  class saveFcmToken_메서드는 {
 
     @Nested
     class fcmToken_key가_없는_요청이_주어지면 {
 
-      final String EMPTY_FCM_TOKEN_REQUEST =
-          "{"
-              + "\"deviceNum\": \"deviceNum\""
-              + "}";
+      final String EMPTY_FCM_TOKEN_REQUEST = "{}";
 
       @WithAuthUser(id = "1", role = "ROLE_TEACHER")
       @Test
@@ -104,7 +77,6 @@ class SaveFcmTokenControllerTest {
 
       final String WHITE_SPACE_REQUEST =
           "{"
-              + "\"deviceNum\": \"deviceNum\","
               + "\"fcmToken\": \"\""
               + "}";
 
@@ -149,7 +121,6 @@ class SaveFcmTokenControllerTest {
 
         FcmToken returnedFcmToken = FcmToken.builder()
             .fcmToken(givenRequest.getFcmToken())
-            .deviceNum(givenRequest.getDeviceNum())
             .userId(1L)
             .build();
 

--- a/src/test/java/com/noti/noti/notification/adapter/out/persistence/FcmAdapterTest.java
+++ b/src/test/java/com/noti/noti/notification/adapter/out/persistence/FcmAdapterTest.java
@@ -1,0 +1,78 @@
+package com.noti.noti.notification.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.verify;
+
+import com.google.firebase.FirebaseApp;
+import com.google.firebase.FirebaseOptions;
+import com.noti.noti.common.MockGoogleCredentials;
+import com.noti.noti.common.MonkeyUtils;
+import java.util.Collections;
+import java.util.List;
+import net.jqwik.api.Arbitraries;
+import org.junit.jupiter.api.BeforeAll;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Spy;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.test.context.ActiveProfiles;
+
+@ActiveProfiles("test")
+@DisplayName("FcmAdapterTest 클래스")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class FcmAdapterTest {
+
+  @InjectMocks
+  private FcmAdapter fcmAdapter;
+
+  @Spy
+  private MessageGenerator messageGenerator;
+
+
+  @BeforeAll
+  static void init() {
+    FirebaseOptions options = FirebaseOptions.builder()
+        .setCredentials(new MockGoogleCredentials("test-token"))
+        .build();
+
+    FirebaseApp.initializeApp(options);
+  }
+
+
+  @Nested
+  class sendSilentPushForVerifyToken_메서드는 {
+
+    @Nested
+    class 토큰목록이_주어지면 {
+
+      @Test
+      void 성공적으로_비동기_메세지를_보낸다() {
+        List<String> tokens = MonkeyUtils.MONKEY.giveMeBuilder(String.class)
+            .set(Arbitraries.strings().ofLength(5))
+            .sampleList(5);
+
+        fcmAdapter.sendSilentPushForVerifyToken(tokens);
+        verify(messageGenerator).generateMulticastMessageForSilent(tokens);
+      }
+    }
+
+    @Nested
+    class 비어있는_토큰이_주어지면 {
+
+      @Test
+      void IllegalArgumentException_예외가_발생한다() {
+        List<String> emptyTokens = Collections.EMPTY_LIST;
+        assertThatThrownBy(() -> fcmAdapter.sendSilentPushForVerifyToken(emptyTokens))
+            .isInstanceOf(IllegalArgumentException.class);
+
+        verify(messageGenerator).generateMulticastMessageForSilent(emptyTokens);
+      }
+    }
+  }
+}

--- a/src/test/java/com/noti/noti/notification/adapter/out/persistence/FcmTokenPersistenceAdapterTest.java
+++ b/src/test/java/com/noti/noti/notification/adapter/out/persistence/FcmTokenPersistenceAdapterTest.java
@@ -34,30 +34,31 @@ class FcmTokenPersistenceAdapterTest extends RedisTestContainerConfig {
 
       @Test
       void 성공적으로_해당_객체를_저장하고_저장된_객체를_반환한다 (){
-        FcmToken givenFcmToken = MonkeyUtils.MONKEY.giveMeBuilder(FcmToken.class).setNull("deviceNum").sample();
+        FcmToken givenFcmToken = MonkeyUtils.MONKEY.giveMeBuilder(FcmToken.class).setNotNull("fcmToken").sample();
         FcmToken savedFcmToken = fcmTokenPersistenceAdapter.saveFcmToken(givenFcmToken);
 
-        assertThat(savedFcmToken.getDeviceNum()).isNotNull();
+        assertThat(savedFcmToken.getFcmToken()).isNotNull();
       }
     }
 
     @Nested
     class 이미_존재하는_ID의_FcmToken_엔티티가_주어지면 {
 
-      final String DEVICE_NUM = "deviceNum";
+      final String FCM_TOKEN = "FCMTOKEN";
 
       @Test
       void 성공적으로_값을_업데이트하고_갱신된_객체를_반환한다 (){
         FcmToken savedFcmToken = fcmTokenPersistenceAdapter.saveFcmToken(
-            MonkeyUtils.MONKEY.giveMeBuilder(FcmToken.class).set("deviceNum", DEVICE_NUM).sample());
+            MonkeyUtils.MONKEY.giveMeBuilder(FcmToken.class).set("fcmToken", FCM_TOKEN)
+                .setNotNull("userId").sample());
 
         FcmToken givenFcmToken = MonkeyUtils.MONKEY.giveMeBuilder(FcmToken.class)
-            .set("deviceNum", DEVICE_NUM).set("fcmToken", "updated").sample();
+            .set("fcmToken", FCM_TOKEN).set("userId", 1L).sample();
 
         FcmToken updatedFcmToken = fcmTokenPersistenceAdapter.saveFcmToken(givenFcmToken);
         assertAll(
-            () -> assertThat(updatedFcmToken.getFcmToken()).isNotEqualTo(savedFcmToken.getFcmToken()),
-            () -> assertThat(updatedFcmToken.getDeviceNum()).isEqualTo(savedFcmToken.getDeviceNum())
+            () -> assertThat(updatedFcmToken.getFcmToken()).isEqualTo(savedFcmToken.getFcmToken()),
+            () -> assertThat(updatedFcmToken.getUserId()).isNotEqualTo(savedFcmToken.getUserId())
         );
       }
     }

--- a/src/test/java/com/noti/noti/notification/adapter/out/persistence/MessageGeneratorTest.java
+++ b/src/test/java/com/noti/noti/notification/adapter/out/persistence/MessageGeneratorTest.java
@@ -1,0 +1,45 @@
+package com.noti.noti.notification.adapter.out.persistence;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+import com.google.firebase.messaging.MulticastMessage;
+import com.noti.noti.common.MonkeyUtils;
+import java.util.List;
+import net.jqwik.api.Arbitraries;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+@DisplayName("MessageGeneratorTest 클래스")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+class MessageGeneratorTest {
+
+  private final MessageGenerator messageGenerator = new MessageGenerator();
+
+  @Nested
+  class generateMulticastMessageForSilent_메서드는 {
+
+    @Nested
+    class Token_List가_주어지면 {
+
+      @Test
+      void Token이_담긴_MulticastMessage_객체를_반환한다 (){
+        List<String> tokens = MonkeyUtils.MONKEY.giveMeBuilder(String.class)
+            .set(Arbitraries.strings().ofLength(5))
+            .sampleList(5);
+
+        MulticastMessage multicastMessage = messageGenerator.generateMulticastMessageForSilent(
+            tokens);
+
+        //MulticastMessage에서 생성자를 막아둬서 상속 불가하고, getter 메서드를 제공하지 않아 리플렉션 사용
+        List<String> storedTokens = (List<String>) ReflectionTestUtils.getField(
+            multicastMessage, "tokens");
+
+        assertThat(tokens).isEqualTo(storedTokens);
+      }
+    }
+  }
+}

--- a/src/test/java/com/noti/noti/notification/application/service/SaveFcmTokenServiceTest.java
+++ b/src/test/java/com/noti/noti/notification/application/service/SaveFcmTokenServiceTest.java
@@ -38,13 +38,11 @@ class SaveFcmTokenServiceTest {
       @Test
       void 성공적으로_요청을_저장하고_저장된_FcmToken을_반환한다 (){
         SaveFcmTokenCommand saveFcmTokenCommand = MonkeyUtils.MONKEY.giveMeBuilder(SaveFcmTokenCommand.class)
-            .setNotNull("deviceNum")
             .minSize("userId", 1)
             .setNotNull("fcmToken")
             .sample();
 
         FcmToken savedFcmToken = FcmToken.builder()
-            .deviceNum(saveFcmTokenCommand.getDeviceNum())
             .userId(saveFcmTokenCommand.getUserId())
             .fcmToken(saveFcmTokenCommand.getFcmToken())
             .build();
@@ -52,7 +50,7 @@ class SaveFcmTokenServiceTest {
         when(saveFcmTokenPort.saveFcmToken(any())).thenReturn(savedFcmToken);
 
         FcmToken fcmToken = saveFcmTokenService.apply(saveFcmTokenCommand);
-        assertThat(fcmToken.getDeviceNum()).isEqualTo(saveFcmTokenCommand.getDeviceNum());
+        assertThat(fcmToken.getFcmToken()).isEqualTo(saveFcmTokenCommand.getFcmToken());
       }
     }
   }

--- a/src/test/java/com/noti/noti/schedule/UpdateFcmTokenScheduleTest.java
+++ b/src/test/java/com/noti/noti/schedule/UpdateFcmTokenScheduleTest.java
@@ -1,0 +1,92 @@
+package com.noti.noti.schedule;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.noti.noti.common.MonkeyUtils;
+import com.noti.noti.notification.application.port.out.FindFcmTokenPort;
+import com.noti.noti.notification.application.port.out.SendPushPort;
+import java.util.List;
+import net.jqwik.api.Arbitraries;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@DisplayName("UpdateFcmTokenScheduleTest 클래스")
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@ExtendWith(MockitoExtension.class)
+class UpdateFcmTokenScheduleTest {
+
+  @InjectMocks
+  private UpdateFcmTokenSchedule updateFcmTokenSchedule;
+
+  @Mock
+  private FindFcmTokenPort findFcmTokenPort;
+
+  @Mock
+  private SendPushPort sendPushPort;
+
+  @Nested
+  class updateFcmToken_메서드는 {
+
+    @Nested
+    class 조회된_token이_없으면 {
+
+      @Test
+      void 푸시알림을_보내지_않는다() {
+        when(findFcmTokenPort.findAllFcmTokenKey()).thenReturn(List.of());
+
+        updateFcmTokenSchedule.updateFcmToken();
+
+        verify(sendPushPort, never()).sendSilentPushForVerifyToken(any());
+      }
+    }
+
+    @Nested
+    class 조회된_token_토큰의_개수가_500을_초과하면 {
+
+      @Test
+      void 푸시알림을_나눠_보낸다() {
+        List<String> tokens = MonkeyUtils.MONKEY.giveMeBuilder(String.class)
+            .set(Arbitraries.strings().ofLength(5))
+            .sampleList(600);
+
+        when(findFcmTokenPort.findAllFcmTokenKey()).thenReturn(tokens);
+        doNothing().when(sendPushPort).sendSilentPushForVerifyToken(any());
+
+        updateFcmTokenSchedule.updateFcmToken();
+
+        verify(sendPushPort, times(2)).sendSilentPushForVerifyToken(any());
+      }
+    }
+
+    @Nested
+    class 조회된_token_토큰의_개수가_500개_이하라면 {
+
+      @Test
+      void 한번에_푸시알림을_보낸다() {
+        List<String> tokens = MonkeyUtils.MONKEY.giveMeBuilder(String.class)
+            .set(Arbitraries.strings().ofLength(5))
+            .sampleList(500);
+
+        when(findFcmTokenPort.findAllFcmTokenKey()).thenReturn(tokens);
+        doNothing().when(sendPushPort).sendSilentPushForVerifyToken(any());
+
+        updateFcmTokenSchedule.updateFcmToken();
+
+        verify(sendPushPort).sendSilentPushForVerifyToken(any());
+      }
+    }
+  }
+
+}


### PR DESCRIPTION
### 구현 사항

1개월 주기로 토큰을 갱신하기 위한 스케줄링을 구현했습니다.
스케쥴링은 1개월 마다 0시 0분 0초에 갱신을 위한 작업을 수행하고 작업 내용은 다음과 같습니다.
redis에 저장되어있는 모든 토큰을 조회하고 그 토큰을 500개씩 나누어 silent push 을 보냅니다. 

### 구현 내용

spring data redis를 이용해 객체를 저장하게 되면 hash 외에 set으로 hash의 id를 추가적으로 저장합니다.
기존의 crudRepository에 있는 findAll() 메서드로 조회를 하니 모니터링 결과 set의 모든 id를 smembers 커맨드로 조회하고 조회된 id로
hgetAll 커맨드를 통해 해당 id 의 hash의 모든 필드를 조회합니다.

현재 스케쥴링에서는 해당 fcmTokenRedisEntity의 fcmToken id만 필요하기 때문에 smembers를 통해 id 목록을 조회하는 작업만 필요합니다. 하지만 smembers 커맨드는 시간 복잡도는 set의 갯수만큼 O(n) 가 되고 redis는 싱글스레드 기반으로 작동되기때문에 O(n) 작업이 진행되는 동안 다른 작업을 할 수가 없게됩니다. 그래서 scan 커맨드를 사용하면 count만큼 끊어서 조회하기 때문에 다른 작업을 수행 할 수 있는 여유가 생기기 때문에 scan을 이용해서 id목록을 조회하게 구현했습니다.

### 업데이트

submodule이 업데이트 되었으니 master에서 꼭 pull 이후 main 프로젝트에서 갱신을 해야합니다.