### PR TITLE
Feature/noti 79 토큰의 만료기간을 갱신하는 api 구현

### DIFF
--- a/src/main/java/com/noti/noti/common/adapter/in/web/response/SuccessResponse.java
+++ b/src/main/java/com/noti/noti/common/adapter/in/web/response/SuccessResponse.java
@@ -29,6 +29,11 @@ public class SuccessResponse<T> {
     return new SuccessResponse(SUCCESS_MESSAGE, 201, null);
   }
 
+  public static SuccessResponse create200SuccessResponse() {
+
+    return new SuccessResponse(SUCCESS_MESSAGE, 200, null);
+  }
+
   public static <T> SuccessResponse create200SuccessResponse(T data) {
 
     return new SuccessResponse(SUCCESS_MESSAGE, 200, data);

--- a/src/main/java/com/noti/noti/config/SecurityConfig.java
+++ b/src/main/java/com/noti/noti/config/SecurityConfig.java
@@ -43,6 +43,7 @@ public class SecurityConfig {
         .authorizeRequests()
         .antMatchers("/api/teacher/login/**", "/", "/favicon.ico", "/swagger-ui.html", "/swagger-ui/**",
             "/api-docs/**").permitAll()
+        .antMatchers(HttpMethod.PATCH, "/api/notification/tokens").permitAll()
         .antMatchers( "/api/auth/reissue").permitAll()
         .antMatchers("/api/teacher/**").hasRole("TEACHER")
         .anyRequest().authenticated()

--- a/src/main/java/com/noti/noti/error/ErrorCode.java
+++ b/src/main/java/com/noti/noti/error/ErrorCode.java
@@ -19,6 +19,13 @@ public enum ErrorCode {
   */
 
   /**
+   * FcmToken 관련 error code
+   *
+   */
+
+  FCM_TOKEN_NOT_FOUND(404, "F001", "해당 FCM 토큰 정보가 존재하지 않습니다"),
+
+  /**
    * JWT 관련 error code
    */
   EXPIRED_JWT(401, "J001", "만료된 토큰입니다"),

--- a/src/main/java/com/noti/noti/notification/adapter/in/web/controller/SaveFcmTokenController.java
+++ b/src/main/java/com/noti/noti/notification/adapter/in/web/controller/SaveFcmTokenController.java
@@ -31,7 +31,7 @@ public class SaveFcmTokenController {
 
   private final SaveFcmTokenUsecase saveFcmTokenUsecase;
 
-  @Operation(tags = "FCM Token 저장, 갱신 API ", summary = "saveFcmToken", description = "FCM Token 저장, 갱신",
+  @Operation(tags = "FCM Token 저장 API ", summary = "saveFcmToken", description = "FCM Token 저장",
       responses = {
           @ApiResponse(responseCode = "201", description = "성공", useReturnTypeSchema = true),
           @ApiResponse(responseCode = "500", description = "서버에러", content = {

--- a/src/main/java/com/noti/noti/notification/adapter/in/web/controller/UpdateFcmTokenController.java
+++ b/src/main/java/com/noti/noti/notification/adapter/in/web/controller/UpdateFcmTokenController.java
@@ -1,0 +1,48 @@
+package com.noti.noti.notification.adapter.in.web.controller;
+
+import com.noti.noti.common.adapter.in.web.response.SuccessResponse;
+import com.noti.noti.error.ErrorResponse;
+import com.noti.noti.notification.adapter.in.web.dto.request.UpdateFcmTokenRequest;
+import com.noti.noti.notification.application.port.in.UpdateFcmTokenCommand;
+import com.noti.noti.notification.application.port.in.UpdateFcmTokenUsecase;
+import io.swagger.v3.oas.annotations.Operation;
+import io.swagger.v3.oas.annotations.media.Content;
+import io.swagger.v3.oas.annotations.media.Schema;
+import io.swagger.v3.oas.annotations.responses.ApiResponse;
+import javax.validation.Valid;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.web.bind.annotation.PatchMapping;
+import org.springframework.web.bind.annotation.RequestBody;
+import org.springframework.web.bind.annotation.RestController;
+
+/**
+ * 토큰 만료기간 갱신 요청시 사용할 api
+ */
+@RestController
+@RequiredArgsConstructor
+public class UpdateFcmTokenController {
+
+  private final UpdateFcmTokenUsecase updateFcmTokenUsecase;
+
+  @Operation(tags = "FCM Token 만료기간 갱신 API ", summary = "updateFcmToken", description = "FCM Token 만료기간 갱신",
+      responses = {
+          @ApiResponse(responseCode = "200", description = "성공", useReturnTypeSchema = true),
+          @ApiResponse(responseCode = "500", description = "서버에러", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))}),
+          @ApiResponse(responseCode = "400", description = "파라미터 에러", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))}),
+          @ApiResponse(responseCode = "404", description = "리소스 에러", content = {
+              @Content(mediaType = "application/json",
+                  schema = @Schema(implementation = ErrorResponse.class))}),
+      })
+  @PatchMapping("/api/notification/tokens")
+  public ResponseEntity<SuccessResponse> updateFcmToken(
+      @Valid @RequestBody UpdateFcmTokenRequest updateFcmTokenRequest) {
+    updateFcmTokenUsecase.updateFcmToken(
+        new UpdateFcmTokenCommand(updateFcmTokenRequest.getFcmToken()));
+    return ResponseEntity.ok(SuccessResponse.create200SuccessResponse());
+  }
+}

--- a/src/main/java/com/noti/noti/notification/adapter/in/web/dto/request/UpdateFcmTokenRequest.java
+++ b/src/main/java/com/noti/noti/notification/adapter/in/web/dto/request/UpdateFcmTokenRequest.java
@@ -1,0 +1,15 @@
+package com.noti.noti.notification.adapter.in.web.dto.request;
+
+import io.swagger.v3.oas.annotations.media.Schema;
+import javax.validation.constraints.NotBlank;
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@NoArgsConstructor
+@Getter
+public class UpdateFcmTokenRequest {
+
+  @NotBlank
+  @Schema(description = "FCM Token", required = true, example = "fcmToken123123")
+  private String fcmToken;
+}

--- a/src/main/java/com/noti/noti/notification/adapter/out/persistence/FcmTokenPersistenceAdapter.java
+++ b/src/main/java/com/noti/noti/notification/adapter/out/persistence/FcmTokenPersistenceAdapter.java
@@ -3,9 +3,11 @@ package com.noti.noti.notification.adapter.out.persistence;
 import com.noti.noti.notification.adapter.out.persistence.model.FcmTokenRedisEntity;
 import com.noti.noti.notification.application.port.out.FindFcmTokenPort;
 import com.noti.noti.notification.application.port.out.SaveFcmTokenPort;
+import com.noti.noti.notification.application.port.out.UpdateFcmTokenPort;
 import com.noti.noti.notification.domain.model.FcmToken;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.TimeUnit;
 import lombok.RequiredArgsConstructor;
 import org.springframework.data.redis.core.Cursor;
 import org.springframework.data.redis.core.ScanOptions;
@@ -15,13 +17,15 @@ import org.springframework.stereotype.Repository;
 
 @RequiredArgsConstructor
 @Repository
-public class FcmTokenPersistenceAdapter implements SaveFcmTokenPort, FindFcmTokenPort {
+public class FcmTokenPersistenceAdapter implements SaveFcmTokenPort, FindFcmTokenPort,
+    UpdateFcmTokenPort {
 
   private final FcmTokenMapper fcmTokenMapper;
   private final FcmTokenRedisRepository fcmTokenRedisRepository;
   private final StringRedisTemplate redisTemplate;
   private static final String FCM_TOKEN_KEY_SET_PATTERN = "fcmToken";
-
+  private static final String FCM_TOKEN_HASH_KEY_PATTERN = "fcmToken:%s";
+  private static final Long FCM_TOKEN_EXPIRE_TIME = 60 * 60 * 24 * 60L;
 
   @Override
   public FcmToken saveFcmToken(FcmToken fcmToken) {
@@ -48,5 +52,28 @@ public class FcmTokenPersistenceAdapter implements SaveFcmTokenPort, FindFcmToke
     }
 
     return fcmTokenKeys;
+  }
+
+  /**
+   * ID에 해당하는 fcmToken이 존재하는지 확인하는 메서드
+   *
+   * @param fcmTokenId
+   * @return 존재유무 boolean
+   */
+  @Override
+  public boolean existsById(String fcmTokenId) {
+    String redisHashKey = String.format(FCM_TOKEN_HASH_KEY_PATTERN, fcmTokenId);
+    return redisTemplate.hasKey(redisHashKey);
+  }
+
+  /**
+   * fcmToken의 만료기간을 갱신하는 메서드
+   *
+   * @param fcmTokenId
+   */
+  @Override
+  public void updateFcmTokenTtlById(String fcmTokenId) {
+    String redisHashKey = String.format(FCM_TOKEN_HASH_KEY_PATTERN, fcmTokenId);
+    redisTemplate.expire(redisHashKey, FCM_TOKEN_EXPIRE_TIME, TimeUnit.SECONDS);
   }
 }

--- a/src/main/java/com/noti/noti/notification/adapter/out/persistence/model/FcmTokenRedisEntity.java
+++ b/src/main/java/com/noti/noti/notification/adapter/out/persistence/model/FcmTokenRedisEntity.java
@@ -10,7 +10,6 @@ import org.springframework.data.redis.core.index.Indexed;
 
 /**
  * 사용자의 Fcm Token 정보를 저장할 Redis Entity 입니다.
- * deviceNum은 디바이스 고유 번호로 유니크하기 때문에 id로 사용하고,
  * 문서의 요구사항에 따라 2개월의 만료기간을 설정했습니다.
  */
 @RedisHash(value = "fcmToken", timeToLive = 60 * 60 * 24 * 60)

--- a/src/main/java/com/noti/noti/notification/application/port/in/UpdateFcmTokenCommand.java
+++ b/src/main/java/com/noti/noti/notification/application/port/in/UpdateFcmTokenCommand.java
@@ -1,0 +1,15 @@
+package com.noti.noti.notification.application.port.in;
+
+import lombok.Getter;
+import lombok.NoArgsConstructor;
+
+@Getter
+@NoArgsConstructor
+public class UpdateFcmTokenCommand {
+
+  private String fcmToken;
+
+  public UpdateFcmTokenCommand(String fcmToken) {
+    this.fcmToken = fcmToken;
+  }
+}

--- a/src/main/java/com/noti/noti/notification/application/port/in/UpdateFcmTokenUsecase.java
+++ b/src/main/java/com/noti/noti/notification/application/port/in/UpdateFcmTokenUsecase.java
@@ -1,0 +1,5 @@
+package com.noti.noti.notification.application.port.in;
+
+public interface UpdateFcmTokenUsecase {
+  void updateFcmToken(UpdateFcmTokenCommand updateFcmTokenCommand);
+}

--- a/src/main/java/com/noti/noti/notification/application/port/out/FindFcmTokenPort.java
+++ b/src/main/java/com/noti/noti/notification/application/port/out/FindFcmTokenPort.java
@@ -5,4 +5,5 @@ import java.util.List;
 public interface FindFcmTokenPort {
 
   List<String> findAllFcmTokenKey();
+  boolean existsById(String fcmTokenId);
 }

--- a/src/main/java/com/noti/noti/notification/application/port/out/UpdateFcmTokenPort.java
+++ b/src/main/java/com/noti/noti/notification/application/port/out/UpdateFcmTokenPort.java
@@ -1,0 +1,6 @@
+package com.noti.noti.notification.application.port.out;
+
+public interface UpdateFcmTokenPort {
+
+  void updateFcmTokenTtlById(String fcmTokenId);
+}

--- a/src/main/java/com/noti/noti/notification/application/service/UpdateFcmTokenService.java
+++ b/src/main/java/com/noti/noti/notification/application/service/UpdateFcmTokenService.java
@@ -1,0 +1,45 @@
+package com.noti.noti.notification.application.service;
+
+import com.noti.noti.notification.application.port.in.UpdateFcmTokenCommand;
+import com.noti.noti.notification.application.port.in.UpdateFcmTokenUsecase;
+import com.noti.noti.notification.application.port.out.FindFcmTokenPort;
+import com.noti.noti.notification.application.port.out.UpdateFcmTokenPort;
+import com.noti.noti.notification.exception.FcmTokenNotFoundException;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Service;
+
+/**
+ * 토큰 만료기간 갱신 Usecase 구현
+ */
+@Service
+@RequiredArgsConstructor
+public class UpdateFcmTokenService implements UpdateFcmTokenUsecase {
+
+  private final FindFcmTokenPort findFcmTokenPort;
+  private final UpdateFcmTokenPort updateFcmTokenPort;
+
+  @Override
+  public void updateFcmToken(UpdateFcmTokenCommand updateFcmTokenCommand) {
+    verifyToken(updateFcmTokenCommand.getFcmToken());
+    updateFcmTokenTtl(updateFcmTokenCommand.getFcmToken());
+  }
+
+  /**
+   * id에 해당하는 정보가 있는지 확인
+   * @param fcmTokenId
+   * @exception FcmTokenNotFoundException
+   */
+  private void verifyToken(String fcmTokenId) {
+    if (!findFcmTokenPort.existsById(fcmTokenId)) {
+      throw new FcmTokenNotFoundException();
+    }
+  }
+
+  /**
+   * id에 해당하는 fcmToken의 만료기간을 갱신
+   * @param fcmTokenId
+   */
+  private void updateFcmTokenTtl(String fcmTokenId) {
+    updateFcmTokenPort.updateFcmTokenTtlById(fcmTokenId);
+  }
+}

--- a/src/main/java/com/noti/noti/notification/exception/FcmTokenNotFoundException.java
+++ b/src/main/java/com/noti/noti/notification/exception/FcmTokenNotFoundException.java
@@ -1,0 +1,11 @@
+package com.noti.noti.notification.exception;
+
+import com.noti.noti.error.ErrorCode;
+import com.noti.noti.error.exception.BusinessException;
+
+public class FcmTokenNotFoundException extends BusinessException {
+
+  public FcmTokenNotFoundException() {
+    super(ErrorCode.FCM_TOKEN_NOT_FOUND);
+  }
+}

--- a/src/test/java/com/noti/noti/notification/adapter/in/web/controller/UpdateFcmTokenControllerTest.java
+++ b/src/test/java/com/noti/noti/notification/adapter/in/web/controller/UpdateFcmTokenControllerTest.java
@@ -1,0 +1,143 @@
+package com.noti.noti.notification.adapter.in.web.controller;
+
+import static com.noti.noti.error.ErrorCode.FCM_TOKEN_NOT_FOUND;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.api.Assertions.*;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.springframework.test.web.servlet.request.MockMvcRequestBuilders.patch;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.jsonPath;
+import static org.springframework.test.web.servlet.result.MockMvcResultMatchers.status;
+
+import com.noti.noti.error.GlobalExceptionHandler;
+import com.noti.noti.notification.application.port.in.UpdateFcmTokenUsecase;
+import com.noti.noti.notification.exception.FcmTokenNotFoundException;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+import org.springframework.http.MediaType;
+import org.springframework.test.web.servlet.MockMvc;
+import org.springframework.test.web.servlet.setup.MockMvcBuilders;
+import org.springframework.web.bind.MethodArgumentNotValidException;
+import org.springframework.web.filter.CharacterEncodingFilter;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@DisplayName("UpdateFcmTokenControllerTest 클래스")
+class UpdateFcmTokenControllerTest {
+
+  @InjectMocks
+  private UpdateFcmTokenController updateFcmTokenController;
+
+  @Mock
+  private UpdateFcmTokenUsecase updateFcmTokenUsecase;
+  private MockMvc mockMvc;
+
+  @BeforeEach
+  void setup() {
+    mockMvc = MockMvcBuilders.standaloneSetup(updateFcmTokenController)
+        .setControllerAdvice(GlobalExceptionHandler.class)
+        .addFilter(new CharacterEncodingFilter("UTF-8", true)).build();
+  }
+
+  @Nested
+  class updateFcmToken_메서드는 {
+
+    final String VALID_REQUEST = "{\"fcmToken\":\"ID\"}";
+
+    @Nested
+    class 요청에_해당하는_정보가_존재하면 {
+
+      @Test
+      void 성공적으로_갱신하고_200_응답을_반환한다() throws Exception {
+
+        doNothing().when(updateFcmTokenUsecase).updateFcmToken(any());
+
+        mockMvc.perform(patch("/api/notification/tokens")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(VALID_REQUEST))
+            .andExpect(status().isOk());
+      }
+    }
+
+    @Nested
+    class 요청의_body가_비어있으면 {
+
+      final String INVALID_REQUEST = "{}";
+
+      @Test
+      void FcmTokenNotFoundException_예외가_발생하고_400_응답을_반환한다() throws Exception {
+        mockMvc.perform(patch("/api/notification/tokens")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(INVALID_REQUEST))
+            .andExpectAll(
+                status().isBadRequest(),
+                result -> {
+                  assertAll(
+                      () -> verify(updateFcmTokenUsecase, never()).updateFcmToken(any()),
+                      () -> assertThat(result.getResolvedException())
+                          .isInstanceOf(MethodArgumentNotValidException.class)
+                  );
+                }
+            );
+      }
+    }
+
+    @Nested
+    class 요청에_해당하는_정보가_존재하지_않으면 {
+
+      @Test
+      void MethodArgumentNotValidException_예외가_발생하고_404_응답을_반환한다() throws Exception {
+
+        doThrow(new FcmTokenNotFoundException()).when(updateFcmTokenUsecase)
+            .updateFcmToken(any());
+
+        mockMvc.perform(patch("/api/notification/tokens")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(VALID_REQUEST))
+            .andExpectAll(
+                status().isNotFound(),
+                jsonPath("$.message").value(FCM_TOKEN_NOT_FOUND.getMessage()),
+                result -> {
+                  assertThat(result.getResolvedException())
+                      .isInstanceOf(FcmTokenNotFoundException.class);
+                }
+            );
+
+      }
+    }
+
+    @Nested
+    class 요청의_fcmToken_value가_비어있으면 {
+
+      final String INVALID_REQUEST = "{\"fcmToken\":\"\"}";
+
+      @Test
+      void MethodArgumentNotValidException_예외가_발생하고_400_응답을_반환한다() throws Exception {
+        mockMvc.perform(patch("/api/notification/tokens")
+                .contentType(MediaType.APPLICATION_JSON)
+                .content(INVALID_REQUEST))
+            .andExpectAll(
+                status().isBadRequest(),
+                result -> {
+                  assertAll(
+                      () -> verify(updateFcmTokenUsecase, never()).updateFcmToken(any()),
+                      () -> assertThat(result.getResolvedException())
+                          .isInstanceOf(MethodArgumentNotValidException.class)
+                  );
+                }
+            );
+      }
+    }
+  }
+}

--- a/src/test/java/com/noti/noti/notification/application/service/UpdateFcmTokenServiceTest.java
+++ b/src/test/java/com/noti/noti/notification/application/service/UpdateFcmTokenServiceTest.java
@@ -1,0 +1,81 @@
+package com.noti.noti.notification.application.service;
+
+import static com.noti.noti.common.MonkeyUtils.MONKEY;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.junit.jupiter.api.Assertions.assertAll;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+import com.noti.noti.common.MonkeyUtils;
+import com.noti.noti.notification.application.port.in.UpdateFcmTokenCommand;
+import com.noti.noti.notification.application.port.out.FindFcmTokenPort;
+import com.noti.noti.notification.application.port.out.UpdateFcmTokenPort;
+import com.noti.noti.notification.exception.FcmTokenNotFoundException;
+import net.jqwik.api.Arbitraries;
+import org.junit.jupiter.api.DisplayName;
+import org.junit.jupiter.api.DisplayNameGeneration;
+import org.junit.jupiter.api.DisplayNameGenerator.ReplaceUnderscores;
+import org.junit.jupiter.api.Nested;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.mockito.junit.jupiter.MockitoExtension;
+
+@ExtendWith(MockitoExtension.class)
+@DisplayNameGeneration(ReplaceUnderscores.class)
+@DisplayName("UpdateFcmTokenServiceTest 클래스")
+class UpdateFcmTokenServiceTest {
+
+  @InjectMocks
+  private UpdateFcmTokenService updateFcmTokenService;
+
+  @Mock
+  private FindFcmTokenPort findFcmTokenPort;
+
+  @Mock
+  private UpdateFcmTokenPort updateFcmTokenPort;
+
+  @Nested
+  class updateFcmToken_메서드는 {
+
+    @Nested
+    class ID에_해당하는_fcmToken이_존재하지_않으면 {
+
+      @Test
+      void FcmTokenNotFoundException_예외가_발생한다() {
+        UpdateFcmTokenCommand updateFcmTokenCommand = MONKEY.giveMeBuilder(
+                UpdateFcmTokenCommand.class)
+            .set("fcmToken", Arbitraries.strings().ofLength(4)).sample();
+        when(findFcmTokenPort.existsById(updateFcmTokenCommand.getFcmToken())).thenReturn(false);
+
+        assertAll(
+            () -> assertThatThrownBy(
+                () -> updateFcmTokenService.updateFcmToken(updateFcmTokenCommand))
+                .isInstanceOf(FcmTokenNotFoundException.class),
+            () -> verify(findFcmTokenPort).existsById(updateFcmTokenCommand.getFcmToken()),
+            () -> verify(updateFcmTokenPort, never()).updateFcmTokenTtlById(any())
+        );
+      }
+    }
+
+    @Nested
+    class ID에_해당하는_fcmToken이_존재하면 {
+
+      @Test
+      void 성공적으로_만료기간을_갱신한다() {
+        UpdateFcmTokenCommand updateFcmTokenCommand = MONKEY.giveMeBuilder(
+                UpdateFcmTokenCommand.class)
+            .set("fcmToken", Arbitraries.strings().ofLength(4)).sample();
+        when(findFcmTokenPort.existsById(updateFcmTokenCommand.getFcmToken())).thenReturn(true);
+        updateFcmTokenService.updateFcmToken(updateFcmTokenCommand);
+        assertAll(
+            () -> verify(findFcmTokenPort).existsById(updateFcmTokenCommand.getFcmToken()),
+            () -> verify(updateFcmTokenPort).updateFcmTokenTtlById(any())
+        );
+      }
+    }
+  }
+}


### PR DESCRIPTION
### 구현사항

토큰의 만료기간을 갱신하는 API를 구현했습니다. 이 api는 토큰 갱신 스케쥴링이 작동되어 클라이언트로 silent push가 갔을 때 push 요청을 받고 만료기간을 갱신하기 위해 사용합니다.

### 로직 

토큰 갱신 요청이 오면 요청에 담겨있는  id에 해당하는 fcmToken이 있는지 redis에서 확인을 하고 없으면 예외 발생 404 응답 반환, 있으면 만료기간을 갱신하는 방식으로 작동합니다. 