### PR TITLE
Feature/noti 80 [FIX] firebase key 경로를 읽을 수 없어 config 설정이 안되는 문제 해결

### DIFF
--- a/src/main/java/com/noti/noti/config/FirebaseConfig.java
+++ b/src/main/java/com/noti/noti/config/FirebaseConfig.java
@@ -5,6 +5,8 @@ import com.google.firebase.FirebaseApp;
 import com.google.firebase.FirebaseOptions;
 import java.io.FileInputStream;
 import java.io.IOException;
+import java.io.InputStream;
+import java.util.Objects;
 import javax.annotation.PostConstruct;
 import org.springframework.beans.factory.annotation.Value;
 import org.springframework.context.annotation.Configuration;
@@ -17,8 +19,11 @@ public class FirebaseConfig {
 
   @PostConstruct
   void init() throws IOException {
-    FileInputStream serviceAccount =
-        new FileInputStream(keyPath);
+    InputStream serviceAccount = getClass().getResourceAsStream(keyPath);
+
+    if (Objects.isNull(serviceAccount)) {
+      throw new NullPointerException("service account is null");
+    }
 
     FirebaseOptions options = FirebaseOptions.builder()
         .setCredentials(GoogleCredentials.fromStream(serviceAccount))


### PR DESCRIPTION
### 문제 상황 

ide에서는 문제 없이 작동했지만 배포시 FileNotFoundException 예외가 발생하면서 serviceAccountKey.json 파일을 읽지 못했습니다.
<img width="1526" alt="스크린샷 2023-08-05 오후 4 03 49" src="https://github.com/Noti-iOS/noti-backend/assets/64575453/7d2c703a-ed59-42d6-b4a6-0036e14c01e3">

### 해결

https://www.baeldung.com/java-classpath-resource-cannot-be-opened 해당 링크를 보고 해결했습니다.

IDE가 프로젝트 디렉토리를 현재 작업 디렉토리로 사용 하고  src/main/resources 디렉토리가 애플리케이션이 읽을 수 있도록 바로 거기에 있기 때문에 기존 path 는 ide에서 문제 없이 작동했지만 jar로 빌드하게 되면 resources에 있는 파일이 루트 디렉토리로 이동해 읽을 수 없었습니다. 그래서 클래스 경로에서 리소르를 읽는 방식으로 변경했습니다.

### 변경사항

submodule 변경이 있으니 꼭 업데이트 부탁드려요.

